### PR TITLE
Remove inheriting from day/night mode for version 2.13.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "dnd.jon.spellbook"
         minSdkVersion 24
         targetSdkVersion 30
-        versionCode 21302
-        versionName "2.13.2"
+        versionCode 21303
+        versionName "2.13.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     compileOptions {

--- a/app/src/main/java/dnd/jon/spellbook/SortFilterHeaderView.java
+++ b/app/src/main/java/dnd/jon/spellbook/SortFilterHeaderView.java
@@ -53,7 +53,7 @@ public class SortFilterHeaderView extends ConstraintLayout {
 
         // Title view setup
         titleView.setTextAppearance(context, R.style.SortFilterTitleStyle);
-        titleView.setAlpha(0.54f);
+        //titleView.setAlpha(0.54f);
         titleView.setTextAlignment(TEXT_ALIGNMENT_CENTER);
         titleView.setText(title);
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -46,8 +46,8 @@
     <!-- Text fields in general -->
     <style name="GeneralTextStyle">
 <!--        <item name="android:textColor">#737373</item>-->
-        <item name="android:textColor">#000000</item>
-        <item name="android:alpha">0.54</item>
+<!--        <item name="android:textColor">#000000</item>-->
+<!--        <item name="android:alpha">0.54</item>-->
     </style>
 
     <!-- Header titles in the sort/filter layout -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="colorPrimary">@color/darkBrown</item>
         <item name="colorPrimaryDark">@color/black</item>
         <item name="colorAccent">@color/black</item>

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.0.4'
         classpath "com.likethesalad.android:string-reference:1.2.2"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
This PR contains the commits for version 2.13.3 (live on the Play Store). The main app theme is back to inheriting from `Theme.AppCompat.Light.NoActionBar` rather than `Theme.AppCompat.DayNight.NoActionBar`. Generally speaking, dark mode support is cool, but it doesn't make sense for the current app setup. This may change if alternative background options get added in the future.