### PR TITLE
Fix reflection issue with ViewModel factory

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,16 +4,10 @@ apply plugin: 'placeholder-resolver'
 android {
     signingConfigs {
         release {
-            storeFile file('../keys/android_key.jks')
-            storePassword System.getenv("KEYSTORE_PASSWORD")
-            keyAlias System.getenv("KEYSTORE_ALIAS")
-            keyPassword System.getenv("KEY_PASSWORD")
-        }
-        key {
-            storeFile file('../keys/android_key.jks')
-            storePassword System.getenv("KEYSTORE_PASSWORD")
-            keyAlias System.getenv("KEYSTORE_ALIAS")
-            keyPassword System.getenv("KEY_PASSWORD")
+            storeFile file('/home/jon/keys/android_key.jks')
+            storePassword System.getenv('ANDROID_KEYSTORE_PASSWORD')
+            keyAlias System.getenv('ANDROID_KEYSTORE_ALIAS')
+            keyPassword System.getenv('ANDROID_KEY_PASSWORD')
         }
     }
     compileSdkVersion 31
@@ -24,6 +18,7 @@ android {
         versionCode 30000
         versionName "3.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        signingConfig signingConfigs.release
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -33,7 +28,7 @@ android {
         release {
             minifyEnabled true
             shrinkResources true
-            signingConfig signingConfigs.key
+            signingConfig signingConfigs.release
         }
         debug {
             minifyEnabled false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "dnd.jon.spellbook"
         minSdkVersion 24
         targetSdkVersion 31
-        versionCode 30000
-        versionName "3.0.0"
+        versionCode 30002
+        versionName "3.0.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         signingConfig signingConfigs.release
     }

--- a/app/src/main/java/dnd/jon/spellbook/SortFilterStatus.java
+++ b/app/src/main/java/dnd/jon/spellbook/SortFilterStatus.java
@@ -378,6 +378,7 @@ public class SortFilterStatus extends BaseObservable implements Named, Parcelabl
         switch (level) {
             case 1:
                 setFirstSortField(sf);
+                break;
             case 2:
                 setSecondSortField(sf);
         }
@@ -386,6 +387,7 @@ public class SortFilterStatus extends BaseObservable implements Named, Parcelabl
         switch (level) {
             case 1:
                 setFirstSortReverse(b);
+                break;
             case 2:
                 setSecondSortReverse(b);
         }

--- a/app/src/main/java/dnd/jon/spellbook/SpellbookViewModelFactory.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellbookViewModelFactory.java
@@ -2,6 +2,7 @@ package dnd.jon.spellbook;
 
 import android.app.Application;
 
+import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
@@ -19,13 +20,10 @@ public class SpellbookViewModelFactory implements ViewModelProvider.Factory {
     @NonNull
     @Override
     public <T extends ViewModel> T create(@NonNull Class<T> modelClass) throws RuntimeException {
-        try {
-            return modelClass.getConstructor(Application.class).newInstance(application);
-        } catch (IllegalAccessException
-                | InstantiationException
-                | InvocationTargetException
-                | NoSuchMethodException e) {
-            throw new RuntimeException("Cannot create an instance of " + modelClass, e);
+        if (modelClass == SpellbookViewModel.class) {
+            return (T) new SpellbookViewModel(application);
+        } else {
+            throw new RuntimeException("Cannot create an instance of " + modelClass);
         }
     }
 

--- a/app/src/main/res/layout/spellcasting_info_activity_layout.xml
+++ b/app/src/main/res/layout/spellcasting_info_activity_layout.xml
@@ -20,6 +20,7 @@
         >
 
         <androidx.appcompat.widget.AppCompatTextView
+            style="@style/GeneralTextStyle"
             android:id="@+id/spellcasting_info_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -28,6 +29,7 @@
             />
 
         <TextView
+            style="@style/GeneralTextStyle"
             android:id="@+id/spellcasting_info_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -11,6 +11,7 @@
         <item name="android:editTextColor">@android:color/black</item>
         <item name="android:textColorHint">@android:color/darker_gray</item>
         <item name="android:textCursorDrawable">@null</item>
+        <item name="android:navigationBarColor">@color/black</item>
         <item name="alertDialogTheme">@style/AlertDialogTheme</item>
     </style>
 

--- a/app/src/main/res/xml/settings_screen.xml
+++ b/app/src/main/res/xml/settings_screen.xml
@@ -38,7 +38,7 @@
             android:summary="%s"
             android:entryValues="@array/spell_slot_locations_options"
             android:entries="@array/spell_slot_locations_options"
-            android:defaultValue="@string/fab"
+            android:defaultValue="@string/circular_button"
             />
 
         <ListPreference


### PR DESCRIPTION
This PR fixes a major reflection-based issue from v3.0.0. Basically, code obfuscation was making it so that the call to `getConstructor` in `SpellbookViewModelFactory::create` would always throw a `NoSuchMethodException` in release mode (but not in debug mode!). This PR works around this by comparing the model class to `SpellbookViewModel` (the only class it should get at the moment), and just explicitly calling the `SpellbookViewModel` constructor.

There are a few other minor bug fixes in here as well - using the darker text in the spellcasting window activities, fixing a mistake when setting up the sort elements, and updating an old default value in the settings screen.