### PR TITLE
Caster table text and right drawer lock

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -1464,9 +1464,9 @@ public class MainActivity extends AppCompatActivity
             closeRightDrawer();
         }
         setLeftDrawerLocked(lock);
-        if (!onTablet) {
-            setRightDrawerLocked(lock);
-        }
+
+        boolean lockRightDrawer = lock || !onTablet;
+        setRightDrawerLocked(lockRightDrawer);
     }
 
     private void updateWindowStatus(WindowStatus newStatus, boolean force) {

--- a/app/src/main/java/dnd/jon/spellbook/SpellcastingInfoWindow.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellcastingInfoWindow.java
@@ -48,6 +48,7 @@ public final class SpellcastingInfoWindow extends Activity {
             final LinearLayout linearLayout = binding.spellcastingInfoLinearLayout;
             final TextView textView = new TextView(this);
             textView.setText(R.string.spellcasting_table);
+            textView.setTextAppearance(R.style.GeneralTextStyle);
             textView.setTypeface(null, Typeface.BOLD);
             textView.setPadding(3, 35, 3, 3);
             linearLayout.addView(textView);

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -110,7 +110,7 @@
     </style>
 
     <!-- Caster table cells -->
-    <style name="CasterTableCell">
+    <style name="CasterTableCell" parent="GeneralTextStyle">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_gravity">center</item>


### PR DESCRIPTION
This PR contains two bug fixes:

* Change caster table text color to match the rest of the app
* Fix a logic bug where the right navigation drawer wasn't always staying locked on a phone