### PR TITLE
Allow FAB to be movable

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -308,6 +308,11 @@ public class MainActivity extends AppCompatActivity
         setupBottomNavBar();
         setupSideMenu();
 
+        if (!onTablet && binding.fab != null) {
+            final String fabMovableKey = getString(string.fab_movable_key);
+            binding.fab.setMovable(prefs.getBoolean(fabMovableKey, false));
+        }
+
         //View decorView = getWindow().getDecorView();
         // Hide both the navigation bar and the status bar.
         // SYSTEM_UI_FLAG_FULLSCREEN is only available on Android 4.1 and higher, but as
@@ -1335,6 +1340,11 @@ public class MainActivity extends AppCompatActivity
         } else if (key.equals(getString(string.spell_language_key))) {
             final Locale locale = new Locale(sharedPreferences.getString(key, getString(string.english_code)));
             viewModel.updateSpellsForLocale(locale);
+        } else if (key.equals(getString(string.fab_movable_key))) {
+            final boolean movable = sharedPreferences.getBoolean(key, false);
+            if (binding.fab != null) {
+                binding.fab.setMovable(movable);
+            }
         }
     }
 

--- a/app/src/main/java/dnd/jon/spellbook/MovableFloatingActionButton.java
+++ b/app/src/main/java/dnd/jon/spellbook/MovableFloatingActionButton.java
@@ -1,0 +1,129 @@
+// Adapted from https://stackoverflow.com/a/46373935
+package dnd.jon.spellbook;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+
+public class MovableFloatingActionButton extends FloatingActionButton implements View.OnTouchListener {
+
+    private final static float CLICK_DRAG_TOLERANCE = 10; // Often, there will be a slight, unintentional, drag when the user taps the FAB, so we need to account for this.
+
+    private float downRawX, downRawY;
+    private float dX, dY;
+    private float initialX, initialY;
+    private boolean movable;
+
+    public MovableFloatingActionButton(Context context) {
+        super(context);
+        init();
+    }
+
+    public MovableFloatingActionButton(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public MovableFloatingActionButton(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
+    private void init() {
+        setOnTouchListener(this);
+    }
+
+    @Override
+    public void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+        initialX = this.getX();
+        initialY = this.getY();
+    }
+
+    public boolean isMovable() {
+        return movable;
+    }
+
+    public void setMovable(boolean movable) {
+        this.movable = movable;
+
+        // If not movable, reset to the initial position
+        if (!movable) {
+            this.setX(this.initialX);
+            this.setY(this.initialY);
+        }
+    }
+
+    @Override
+    public boolean onTouch(View view, MotionEvent motionEvent) {
+
+        if (!movable) {
+            return true;
+        }
+
+        ViewGroup.MarginLayoutParams layoutParams = (ViewGroup.MarginLayoutParams)view.getLayoutParams();
+
+        int action = motionEvent.getAction();
+        if (action == MotionEvent.ACTION_DOWN) {
+
+            downRawX = motionEvent.getRawX();
+            downRawY = motionEvent.getRawY();
+            dX = view.getX() - downRawX;
+            dY = view.getY() - downRawY;
+
+            return true; // Consumed
+
+        }
+        else if (action == MotionEvent.ACTION_MOVE) {
+
+            int viewWidth = view.getWidth();
+            int viewHeight = view.getHeight();
+
+            View viewParent = (View)view.getParent();
+            int parentWidth = viewParent.getWidth();
+            int parentHeight = viewParent.getHeight();
+
+            float newX = motionEvent.getRawX() + dX;
+            newX = Math.max(layoutParams.leftMargin, newX); // Don't allow the FAB past the left hand side of the parent
+            newX = Math.min(parentWidth - viewWidth - layoutParams.rightMargin, newX); // Don't allow the FAB past the right hand side of the parent
+
+            float newY = motionEvent.getRawY() + dY;
+            newY = Math.max(layoutParams.topMargin, newY); // Don't allow the FAB past the top of the parent
+            newY = Math.min(parentHeight - viewHeight - layoutParams.bottomMargin, newY); // Don't allow the FAB past the bottom of the parent
+
+            view.animate()
+                    .x(newX)
+                    .y(newY)
+                    .setDuration(0)
+                    .start();
+
+            return true; // Consumed
+
+        }
+        else if (action == MotionEvent.ACTION_UP) {
+
+            float upRawX = motionEvent.getRawX();
+            float upRawY = motionEvent.getRawY();
+
+            float upDX = upRawX - downRawX;
+            float upDY = upRawY - downRawY;
+
+            if (Math.abs(upDX) < CLICK_DRAG_TOLERANCE && Math.abs(upDY) < CLICK_DRAG_TOLERANCE) { // A click
+                return performClick();
+            }
+            else { // A drag
+                return true; // Consumed
+            }
+
+        }
+        else {
+            return super.onTouchEvent(motionEvent);
+        }
+
+    }
+
+}

--- a/app/src/main/java/dnd/jon/spellbook/MovableFloatingActionButton.java
+++ b/app/src/main/java/dnd/jon/spellbook/MovableFloatingActionButton.java
@@ -44,10 +44,6 @@ public class MovableFloatingActionButton extends FloatingActionButton implements
         initialY = this.getY();
     }
 
-    public boolean isMovable() {
-        return movable;
-    }
-
     public void setMovable(boolean movable) {
         this.movable = movable;
 
@@ -62,7 +58,7 @@ public class MovableFloatingActionButton extends FloatingActionButton implements
     public boolean onTouch(View view, MotionEvent motionEvent) {
 
         if (!movable) {
-            return true;
+            return super.onTouchEvent(motionEvent);
         }
 
         ViewGroup.MarginLayoutParams layoutParams = (ViewGroup.MarginLayoutParams)view.getLayoutParams();

--- a/app/src/main/java/dnd/jon/spellbook/MovableFloatingActionButton.java
+++ b/app/src/main/java/dnd/jon/spellbook/MovableFloatingActionButton.java
@@ -15,7 +15,8 @@ public class MovableFloatingActionButton extends FloatingActionButton implements
 
     private float downRawX, downRawY;
     private float dX, dY;
-    private float initialX, initialY;
+    private Float initialX = null;
+    private Float initialY = null;
     private boolean movable;
 
     public MovableFloatingActionButton(Context context) {
@@ -40,8 +41,11 @@ public class MovableFloatingActionButton extends FloatingActionButton implements
     @Override
     public void onLayout(boolean changed, int left, int top, int right, int bottom) {
         super.onLayout(changed, left, top, right, bottom);
-        initialX = this.getX();
-        initialY = this.getY();
+        if (initialX == null || initialY == null) {
+            initialX = this.getX();
+            initialY = this.getY();
+        }
+
     }
 
     public void setMovable(boolean movable) {
@@ -49,8 +53,8 @@ public class MovableFloatingActionButton extends FloatingActionButton implements
 
         // If not movable, reset to the initial position
         if (!movable) {
-            this.setX(this.initialX);
-            this.setY(this.initialY);
+            this.setX(initialX);
+            this.setY(initialY);
         }
     }
 

--- a/app/src/main/java/dnd/jon/spellbook/SettingsFragment.java
+++ b/app/src/main/java/dnd/jon/spellbook/SettingsFragment.java
@@ -27,10 +27,8 @@ public class SettingsFragment extends PreferenceFragmentCompat {
 
         final String textColorKey = getString(R.string.text_color);
         final Preference preference = findPreference(textColorKey);
-        System.out.println(preference);
         if (preference == null) { return; }
         preference.setOnPreferenceClickListener(pref -> {
-            System.out.println("In OnPreferenceClickListener");
             showColorDialog(pref);
             return true;
         });

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -75,7 +75,7 @@
                 android:layout_marginTop="?android:attr/actionBarSize"
                 />
 
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
+            <dnd.jon.spellbook.MovableFloatingActionButton
                 android:id="@+id/fab"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -429,6 +429,7 @@
     <string name="general_layout_preferences">Preferências gerais de layout</string>
     <string name="bottom_nav_buttons">Botões de navegação inferior</string>
     <string name="spell_text_color">Soletrar cor do texto</string>
+    <string name="fab_movable_title">Permitir movimento do botão circular</string>
 
     <!-- Locations -->
     <string name="spell_lists_location">Localização das listas de feitiços</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -430,6 +430,7 @@
     <string name="general_layout_preferences">General layout preferences</string>
     <string name="bottom_nav_buttons">Bottom navigation buttons</string>
     <string name="spell_text_color">Spell text color</string>
+    <string name="fab_movable_title">Allow moving circular button</string>
 
     <!-- Locations -->
     <string name="spell_lists_location">Spell lists location</string>
@@ -448,6 +449,9 @@
     <string name="portuguese" translatable="false">Português</string>
     <string name="portuguese_code" translatable="false">pt</string>
     <string name="default_language_code">${english_code}</string>
+
+    <!-- Fab movable -->
+    <string name="fab_movable_key" translatable="false">fab_movable</string>
 
     <!-- Content descriptions -->
     <string name="book_background_description">Book background image</string>

--- a/app/src/main/res/xml/settings_screen.xml
+++ b/app/src/main/res/xml/settings_screen.xml
@@ -58,6 +58,11 @@
             android:entries="@array/language_names"
             />
 
+        <SwitchPreference
+            android:key="@string/fab_movable_key"
+            android:title="@string/fab_movable_title"
+            />
+
     </androidx.preference.PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "com.likethesalad.android:string-reference:1.2.2"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip


### PR DESCRIPTION
This PR adds the option to allow the FAB (which is only present on a phone) to be movable. Whether or not the FAB is togglable is controlled via a preference. When this preference is set to false, the FAB is returned to this default location.