### PR TITLE
Fix sizing issue with spell slot manager update dialog

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/MovableFloatingActionButton.java
+++ b/app/src/main/java/dnd/jon/spellbook/MovableFloatingActionButton.java
@@ -52,7 +52,7 @@ public class MovableFloatingActionButton extends FloatingActionButton implements
         this.movable = movable;
 
         // If not movable, reset to the initial position
-        if (!movable) {
+        if (!movable && initialX != null && initialY != null) {
             this.setX(initialX);
             this.setY(initialY);
         }

--- a/app/src/main/res/layout/spell_slot_adjust_total_item.xml
+++ b/app/src/main/res/layout/spell_slot_adjust_total_item.xml
@@ -15,7 +15,7 @@
 
     <LinearLayout
         android:orientation="horizontal"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:gravity="center"
         android:padding="3dp"
@@ -29,6 +29,7 @@
             android:textStyle="bold"
             android:textSize="18sp"
             android:padding="5dp"
+            android:maxLines="1"
             app:context="@{context}"
             app:slotAdjustTotalLevel="@{level}"
             />

--- a/app/src/main/res/layout/spell_slot_adjust_totals.xml
+++ b/app/src/main/res/layout/spell_slot_adjust_totals.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:bind="http://schemas.android.com/apk/res-auto"
     xmlns:grid="http://schemas.android.com/apk/res-auto"
     >
@@ -54,6 +55,9 @@
                 android:gravity="center"
                 android:orientation="vertical"
                 android:layout_below="@id/spell_slot_adjust_title"
+                app:flexDirection="row"
+                app:flexWrap="wrap"
+                app:justifyContent="center"
                 >
 
                     <include layout="@layout/spell_slot_adjust_total_item"

--- a/app/src/main/res/layout/spell_slot_adjust_totals.xml
+++ b/app/src/main/res/layout/spell_slot_adjust_totals.xml
@@ -48,19 +48,13 @@
                 android:layout_centerHorizontal="true"
                 />
 
-            <LinearLayout
+            <com.google.android.flexbox.FlexboxLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="center"
                 android:orientation="vertical"
                 android:layout_below="@id/spell_slot_adjust_title"
                 >
-
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    >
 
                     <include layout="@layout/spell_slot_adjust_total_item"
                         bind:level="@{1}"
@@ -85,12 +79,7 @@
                         grid:layout_gravity="fill_horizontal"
                         android:id="@+id/adjust_slots_level_3"
                         />
-                </LinearLayout>
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    >
+
                     <include layout="@layout/spell_slot_adjust_total_item"
                         bind:level="@{4}"
                         bind:status="@{status}"
@@ -114,12 +103,7 @@
                         grid:layout_gravity="fill_horizontal"
                         android:id="@+id/adjust_slots_level_6"
                         />
-                </LinearLayout>
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    >
+
                     <include layout="@layout/spell_slot_adjust_total_item"
                         bind:level="@{7}"
                         bind:status="@{status}"
@@ -143,82 +127,8 @@
                         grid:layout_gravity="fill_horizontal"
                         android:id="@+id/adjust_slots_level_9"
                         />
-                </LinearLayout>
 
-            </LinearLayout>
-
-<!--            <androidx.gridlayout.widget.GridLayout-->
-<!--                android:layout_width="wrap_content"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:id="@+id/spell_slot_adjust_grid"-->
-<!--                android:layout_centerHorizontal="true"-->
-<!--                android:layout_below="@id/spell_slot_adjust_title"-->
-<!--                grid:alignmentMode="alignBounds"-->
-<!--                android:background="@android:color/holo_orange_dark"-->
-<!--                grid:columnCount="3"-->
-<!--                grid:rowCount="3">-->
-
-<!--                <include layout="@layout/spell_slot_adjust_total_item"-->
-<!--                    bind:level="@{1}"-->
-<!--                    bind:status="@{status}"-->
-<!--                    grid:layout_columnWeight="1"-->
-<!--                    grid:layout_gravity="fill_horizontal"-->
-<!--                    android:id="@+id/adjust_slots_level_1"-->
-<!--                    />-->
-
-<!--                <include layout="@layout/spell_slot_adjust_total_item"-->
-<!--                    bind:level="@{2}"-->
-<!--                    bind:status="@{status}"-->
-<!--                    grid:layout_columnWeight="1"-->
-<!--                    grid:layout_gravity="fill_horizontal"-->
-<!--                    android:id="@+id/adjust_slots_level_2"-->
-<!--                    />-->
-
-<!--                <include layout="@layout/spell_slot_adjust_total_item"-->
-<!--                    bind:level="@{3}"-->
-<!--                    bind:status="@{status}"-->
-<!--                    grid:layout_columnWeight="1"-->
-<!--                    grid:layout_gravity="fill_horizontal"-->
-<!--                    android:id="@+id/adjust_slots_level_3"-->
-<!--                    />-->
-
-<!--                <include layout="@layout/spell_slot_adjust_total_item"-->
-<!--                    bind:level="@{4}"-->
-<!--                    bind:status="@{status}"-->
-<!--                    android:id="@+id/adjust_slots_level_4"-->
-<!--                    />-->
-
-<!--                <include layout="@layout/spell_slot_adjust_total_item"-->
-<!--                    bind:level="@{5}"-->
-<!--                    bind:status="@{status}"-->
-<!--                    android:id="@+id/adjust_slots_level_5"-->
-<!--                    />-->
-
-<!--                <include layout="@layout/spell_slot_adjust_total_item"-->
-<!--                    bind:level="@{6}"-->
-<!--                    bind:status="@{status}"-->
-<!--                    android:id="@+id/adjust_slots_level_6"-->
-<!--                    />-->
-
-<!--                <include layout="@layout/spell_slot_adjust_total_item"-->
-<!--                    bind:level="@{7}"-->
-<!--                    bind:status="@{status}"-->
-<!--                    android:id="@+id/adjust_slots_level_7"-->
-<!--                    />-->
-
-<!--                <include layout="@layout/spell_slot_adjust_total_item"-->
-<!--                    bind:level="@{8}"-->
-<!--                    bind:status="@{status}"-->
-<!--                    android:id="@+id/adjust_slots_level_8"-->
-<!--                    />-->
-
-<!--                <include layout="@layout/spell_slot_adjust_total_item"-->
-<!--                    bind:level="@{9}"-->
-<!--                    bind:status="@{status}"-->
-<!--                    android:id="@+id/adjust_slots_level_9"-->
-<!--                    />-->
-
-<!--            </androidx.gridlayout.widget.GridLayout>-->
+            </com.google.android.flexbox.FlexboxLayout>
 
         </RelativeLayout>
     </RelativeLayout>


### PR DESCRIPTION
A user reported an error where the content of the spell slot count update dialog could extend past the dialog boundary. This had the effect of making it impossible to edit the number of 3rd, 6th, and 9th level spell slots.

This PR aims to fix this issue by changing this dialog to use a flexbox layout, rather than the previous layout (which was always 3x3). This allows the number of items per row to be adaptable to the screen size.