### PR TITLE
UI improvements

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/ShortScrollbarRVScrollView.java
+++ b/app/src/main/java/dnd/jon/spellbook/ShortScrollbarRVScrollView.java
@@ -1,0 +1,39 @@
+package dnd.jon.spellbook;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.ScrollView;
+
+public class ShortScrollbarRVScrollView extends ScrollView {
+    public ShortScrollbarRVScrollView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    public ShortScrollbarRVScrollView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public ShortScrollbarRVScrollView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public ShortScrollbarRVScrollView(Context context) {
+        super(context);
+    }
+
+    // This is the value of scrollY when the RV is fully scrolled
+    private int yScrollRange() {
+        return super.computeVerticalScrollRange() - getHeight();
+    }
+
+    @Override
+    public int computeVerticalScrollExtent() {
+        return super.computeVerticalScrollExtent() / 5;
+    }
+
+    @Override
+    public int computeVerticalScrollOffset() {
+        return getScrollY() * (getHeight() - computeVerticalScrollExtent()) / yScrollRange();
+    }
+
+}

--- a/app/src/main/java/dnd/jon/spellbook/ShortScrollbarRVScrollView.java
+++ b/app/src/main/java/dnd/jon/spellbook/ShortScrollbarRVScrollView.java
@@ -28,12 +28,20 @@ public class ShortScrollbarRVScrollView extends ScrollView {
 
     @Override
     public int computeVerticalScrollExtent() {
+        final int yRange = yScrollRange();
+        if (yRange <= 0) {
+            return 0;
+        }
         return super.computeVerticalScrollExtent() / 5;
     }
 
     @Override
     public int computeVerticalScrollOffset() {
-        return getScrollY() * (getHeight() - computeVerticalScrollExtent()) / yScrollRange();
+        final int yRange = yScrollRange();
+        if (yRange <= 0) {
+            return 0;
+        }
+        return getScrollY() * (getHeight() - computeVerticalScrollExtent()) / yRange;
     }
 
 }

--- a/app/src/main/res/layout/character_selection.xml
+++ b/app/src/main/res/layout/character_selection.xml
@@ -97,11 +97,12 @@
             android:layout_below="@id/import_character_button_layout"
             >
 
-            <ScrollView
+            <dnd.jon.spellbook.ShortScrollbarRVScrollView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:minHeight="126dp"
                 android:id="@+id/selection_table_scrollview"
+                android:fadeScrollbars="false"
                 >
 
                 <androidx.recyclerview.widget.RecyclerView
@@ -110,10 +111,9 @@
                     android:layout_height="wrap_content"
                     android:paddingStart="4dp"
                     android:paddingEnd="8dp"
-                    android:scrollbarSize="12dp"
                     >
                 </androidx.recyclerview.widget.RecyclerView>
-            </ScrollView>
+            </dnd.jon.spellbook.ShortScrollbarRVScrollView>
         </LinearLayout>
 
     </RelativeLayout>

--- a/app/src/main/res/layout/character_selection.xml
+++ b/app/src/main/res/layout/character_selection.xml
@@ -91,23 +91,30 @@
 
         </com.google.android.flexbox.FlexboxLayout>
 
-        <ScrollView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:minHeight="126dp"
-            android:id="@+id/selection_table_scrollview"
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="400dp"
             android:layout_below="@id/import_character_button_layout"
             >
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/selection_recycler_view"
+            <ScrollView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingStart="4dp"
-                android:paddingEnd="8dp"
+                android:minHeight="126dp"
+                android:id="@+id/selection_table_scrollview"
                 >
-            </androidx.recyclerview.widget.RecyclerView>
-        </ScrollView>
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/selection_recycler_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingStart="4dp"
+                    android:paddingEnd="8dp"
+                    android:scrollbarSize="12dp"
+                    >
+                </androidx.recyclerview.widget.RecyclerView>
+            </ScrollView>
+        </LinearLayout>
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/character_selection.xml
+++ b/app/src/main/res/layout/character_selection.xml
@@ -92,16 +92,19 @@
         </com.google.android.flexbox.FlexboxLayout>
 
         <ScrollView
-            android:layout_width="wrap_content"
-            android:layout_height="126dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="126dp"
             android:id="@+id/selection_table_scrollview"
             android:layout_below="@id/import_character_button_layout"
             >
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/selection_recycler_view"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:paddingStart="4dp"
+                android:paddingEnd="8dp"
                 >
             </androidx.recyclerview.widget.RecyclerView>
         </ScrollView>

--- a/app/src/main/res/layout/character_selection.xml
+++ b/app/src/main/res/layout/character_selection.xml
@@ -91,30 +91,24 @@
 
         </com.google.android.flexbox.FlexboxLayout>
 
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="400dp"
+        <dnd.jon.spellbook.ShortScrollbarRVScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="126dp"
+            android:id="@+id/selection_table_scrollview"
             android:layout_below="@id/import_character_button_layout"
+            android:fadeScrollbars="false"
             >
 
-            <dnd.jon.spellbook.ShortScrollbarRVScrollView
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/selection_recycler_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:minHeight="126dp"
-                android:id="@+id/selection_table_scrollview"
-                android:fadeScrollbars="false"
+                android:paddingStart="4dp"
+                android:paddingEnd="8dp"
                 >
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/selection_recycler_view"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:paddingStart="4dp"
-                    android:paddingEnd="8dp"
-                    >
-                </androidx.recyclerview.widget.RecyclerView>
-            </dnd.jon.spellbook.ShortScrollbarRVScrollView>
-        </LinearLayout>
+            </androidx.recyclerview.widget.RecyclerView>
+        </dnd.jon.spellbook.ShortScrollbarRVScrollView>
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/name_row.xml
+++ b/app/src/main/res/layout/name_row.xml
@@ -7,7 +7,7 @@
     </data>
 
     <RelativeLayout
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:id="@+id/name_row"
         >

--- a/app/src/main/res/xml/settings_screen.xml
+++ b/app/src/main/res/xml/settings_screen.xml
@@ -61,6 +61,7 @@
         <SwitchPreference
             android:key="@string/fab_movable_key"
             android:title="@string/fab_movable_title"
+            android:defaultValue="true"
             />
 
     </androidx.preference.PreferenceCategory>


### PR DESCRIPTION
This PR makes the following changes to the UI:

* Make the spell slots button movable by default (the option to make it not movable still exists in the settings)
* Allow the character selection dialog to grow larger as more characters are added.
    - If the list is long enough that scrolling is required, the scrollbar is always visible. The scrollbar size has been made shorter than the default Android implementation.