### PR TITLE
Add "regain spent slots" button

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -117,6 +117,7 @@ public class MainActivity extends AppCompatActivity
     private MenuItem infoMenuIcon;
     private MenuItem editSlotsMenuIcon;
     private MenuItem manageSlotsMenuIcon;
+    private MenuItem regainSlotsMenuIcon;
     private ActionBarDrawerToggle leftNavToggle;
 
     // For close spell windows on a swipe, on a phone
@@ -376,6 +377,7 @@ public class MainActivity extends AppCompatActivity
         infoMenuIcon = menu.findItem(id.action_info);
         editSlotsMenuIcon = menu.findItem(id.action_edit);
         manageSlotsMenuIcon = menu.findItem(id.action_slots);
+        regainSlotsMenuIcon = menu.findItem(id.action_regain);
 
         // Set up the SearchView functions
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
@@ -422,6 +424,9 @@ public class MainActivity extends AppCompatActivity
             } else {
                 updateWindowStatus(WindowStatus.SLOTS);
             }
+            return true;
+        } else if (itemID == id.action_regain) {
+            viewModel.getSpellSlotStatus().regainAllSlots();
             return true;
         } else {
             return super.onOptionsItemSelected(item);
@@ -1355,6 +1360,7 @@ public class MainActivity extends AppCompatActivity
                                           ((windowStatus == WindowStatus.SPELL) && onTablet);
         final boolean infoIconVisible = filterIconVisible;
         final boolean editIconVisible = (windowStatus == WindowStatus.SLOTS);
+        final boolean regainIconVisible = (windowStatus == WindowStatus.SLOTS);
 
 
         if (searchViewIcon != null) {
@@ -1371,6 +1377,9 @@ public class MainActivity extends AppCompatActivity
         }
         if (manageSlotsMenuIcon != null) {
             manageSlotsMenuIcon.setVisible(onTablet);
+        }
+        if (regainSlotsMenuIcon != null) {
+            regainSlotsMenuIcon.setVisible(regainIconVisible);
         }
 
         if (!onTablet && searchView != null && searchView.isIconified()) {

--- a/app/src/main/java/dnd/jon/spellbook/SpellSlotManagerDialog.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellSlotManagerDialog.java
@@ -43,6 +43,8 @@ public class SpellSlotManagerDialog extends DialogFragment {
         binding.setStatus(viewModel.getSpellSlotStatus());
         binding.slotManagerEditButton.setVisibility(View.VISIBLE);
         binding.slotManagerEditButton.setOnClickListener((v) -> openEditDialog());
+        binding.slotManagerRegainButton.setVisibility(View.VISIBLE);
+        binding.slotManagerRegainButton.setOnClickListener((v) -> viewModel.getSpellSlotStatus().regainAllSlots());
         builder.setView(binding.getRoot());
         setupRecycler();
         setupSpellSlotListeners();
@@ -73,7 +75,7 @@ public class SpellSlotManagerDialog extends DialogFragment {
             @Override
             public void onPropertyChanged(Observable sender, int propertyId) {
                 if (sender != status) { return; }
-                if (propertyId == BR.totalSlotsFlag || propertyId == BR.availableSlotsFlag) {
+                if (propertyId == BR.totalSlotsFlag || propertyId == BR.usedSlotsFlag) {
                     adapter.refresh();
                 }
             }

--- a/app/src/main/java/dnd/jon/spellbook/SpellSlotManagerFragment.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellSlotManagerFragment.java
@@ -60,7 +60,7 @@ public class SpellSlotManagerFragment extends Fragment {
             @Override
             public void onPropertyChanged(Observable sender, int propertyId) {
                 if (sender != status) { return; }
-                if (propertyId == BR.totalSlotsFlag || propertyId == BR.availableSlotsFlag) {
+                if (propertyId == BR.totalSlotsFlag || propertyId == BR.usedSlotsFlag) {
                     adapter.refresh();
                 }
             }

--- a/app/src/main/java/dnd/jon/spellbook/SpellSlotStatus.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellSlotStatus.java
@@ -62,10 +62,8 @@ public class SpellSlotStatus extends BaseObservable implements Parcelable {
     // whenever the appropriate number of slots have changed
     private final Void totalSlotsFlag = null;
     private final Void usedSlotsFlag = null;
-    private final Void availableSlotsFlag = null;
     @Bindable private Void getTotalSlotsFlag() { return totalSlotsFlag; }
     @Bindable private Void getUsedSlotsFlag() { return usedSlotsFlag; }
-    @Bindable private Void getAvailableSlotsFlag() { return availableSlotsFlag; }
 
     public int getTotalSlots(int level) { return totalSlots[level-1]; }
     public int getUsedSlots(int level) { return usedSlots[level-1]; }
@@ -74,7 +72,6 @@ public class SpellSlotStatus extends BaseObservable implements Parcelable {
     void setTotalSlots(int level, int slots) {
         totalSlots[level-1] = slots;
         notifyPropertyChanged(BR.totalSlotsFlag);
-        notifyPropertyChanged(BR.availableSlotsFlag);
         if (slots < usedSlots[level-1]) {
             usedSlots[level-1] = slots;
             notifyPropertyChanged(BR.usedSlotsFlag);
@@ -82,19 +79,34 @@ public class SpellSlotStatus extends BaseObservable implements Parcelable {
     }
     void setAvailableSlots(int level, int slots) {
         final int used = totalSlots[level-1] - slots;
-        usedSlots[level-1] = Math.max(0, used);
+        final int newAvailable = Math.max(0, used);
+        if (newAvailable != usedSlots[level-1]) {
+            usedSlots[level-1] = Math.max(0, used);
+            notifyPropertyChanged(BR.usedSlotsFlag);
+        }
     }
     void setUsedSlots(int level, int slots) {
         usedSlots[level-1] = Math.min(slots, totalSlots[level-1]);
         notifyPropertyChanged(BR.usedSlotsFlag);
     }
-    void refillAllSlots() { Arrays.fill(usedSlots, 0); }
+    void regainAllSlots() {
+        Arrays.fill(usedSlots, 0);
+        notifyPropertyChanged(BR.usedSlotsFlag);
+    }
 
     void useSlot(int level) {
-        usedSlots[level-1] = Math.min(usedSlots[level-1] + 1, totalSlots[level-1]);
+        final int newUsed = Math.min(usedSlots[level-1] + 1, totalSlots[level-1]);
+        if (newUsed != usedSlots[level-1]) {
+            usedSlots[level-1] = newUsed;
+            notifyPropertyChanged(BR.usedSlotsFlag);
+        }
     }
     void gainSlot(int level) {
-        usedSlots[level-1] = Math.max(usedSlots[level-1] - 1, 0);
+        final int newUsed = Math.max(usedSlots[level-1] - 1, 0);
+        if (newUsed != usedSlots[level-1]) {
+            usedSlots[level-1] = newUsed;
+            notifyPropertyChanged(BR.usedSlotsFlag);
+        }
     }
 
     int maxLevelWithSlots() {

--- a/app/src/main/res/layout/spell_slot_manager.xml
+++ b/app/src/main/res/layout/spell_slot_manager.xml
@@ -61,10 +61,23 @@
                 android:layout_centerHorizontal="true"
                 />
 
+            <Button
+                style="@style/GeneralTextStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/slot_manager_edit_button"
+                android:background="@android:color/transparent"
+                android:foreground="?android:attr/selectableItemBackground"
+                android:id="@+id/slot_manager_regain_button"
+                android:text="@string/regain_spent_slots"
+                android:visibility="gone"
+                android:layout_centerHorizontal="true"
+                />
+
             <androidx.recyclerview.widget.RecyclerView
                 android:layout_width="match_parent"
                 android:layout_height="fill_parent"
-                android:layout_below="@id/slot_manager_edit_button"
+                android:layout_below="@id/slot_manager_regain_button"
                 android:id="@+id/spell_slots_recycler"
                 android:nestedScrollingEnabled="false"
                 android:layout_centerHorizontal="true"

--- a/app/src/main/res/menu/action_bar_menu.xml
+++ b/app/src/main/res/menu/action_bar_menu.xml
@@ -41,6 +41,13 @@
         />
 
     <item
+        android:id="@+id/action_regain"
+        android:title="@string/action_regain_slots"
+        android:icon="@drawable/ic_refresh"
+        app:showAsAction="ifRoom"
+        />
+
+    <item
         android:id="@+id/action_edit"
         android:title="@string/edit"
         android:icon="@drawable/ic_pencil"

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -134,6 +134,7 @@
     <string name="search_hint">Pesquisa</string>
     <string name="action_filter">Filtro</string>
     <string name="action_slots">Gerenciar slots</string>
+    <string name="action_regain_slots">Recuperar slots gastos</string>
 
     <!-- Feedback window -->
     <string name="feedback_title">Comentários</string>
@@ -375,6 +376,7 @@
     <!-- Spell slots window -->
     <string name="spell_slots_title">Espaços de Magia</string>
     <string name="edit_slot_totals">Editar Totais de Slot</string>
+    <string name="regain_spent_slots">Recuperar Slots Gastos</string>
 
     <!-- Version update info -->
     <string name="update_02_10_title">Atualização da Versão 2.10</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,6 +134,7 @@
     <string name="search_hint">Search</string>
     <string name="action_filter">Filter</string>
     <string name="action_slots">Manage slots</string>
+    <string name="action_regain_slots">Regain spent slots</string>
 
     <!-- Feedback window -->
     <string name="feedback_title">Feedback</string>
@@ -376,6 +377,7 @@
     <!-- Spell slots window -->
     <string name="spell_slots_title">Spell Slots</string>
     <string name="edit_slot_totals">Edit Slot Totals</string>
+    <string name="regain_spent_slots">Regain Spent Slots</string>
 
     <!-- Version update info -->
     <string name="update_02_10_title">Version 2.10 update</string>


### PR DESCRIPTION
This PR adds a "regain spent slots" button. On a phone, this button lives in the action bar. On a tablet, since the spell slot management is done via a large dialog, this is accomplished via a button inside the dialog.