### PR TITLE
Only show spell language preference conditionally

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/SettingsFragment.java
+++ b/app/src/main/java/dnd/jon/spellbook/SettingsFragment.java
@@ -3,6 +3,7 @@ package dnd.jon.spellbook;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.os.LocaleList;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,13 +12,17 @@ import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.preference.Preference;
+import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.PreferenceScreen;
 
 import com.kizitonwose.colorpreferencecompat.ColorPreferenceCompat;
 import com.skydoves.colorpickerview.ColorEnvelope;
 import com.skydoves.colorpickerview.ColorPickerDialog;
 import com.skydoves.colorpickerview.ColorPickerView;
 import com.skydoves.colorpickerview.listeners.ColorEnvelopeListener;
+
+import java.util.Locale;
 
 public class SettingsFragment extends PreferenceFragmentCompat {
 
@@ -26,12 +31,30 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         setPreferencesFromResource(R.xml.settings_screen, rootKey);
 
         final String textColorKey = getString(R.string.text_color);
-        final Preference preference = findPreference(textColorKey);
-        if (preference == null) { return; }
-        preference.setOnPreferenceClickListener(pref -> {
-            showColorDialog(pref);
-            return true;
-        });
+        final Preference colorPreference = findPreference(textColorKey);
+        if (colorPreference != null) {
+            colorPreference.setOnPreferenceClickListener(pref -> {
+                showColorDialog(pref);
+                return true;
+            });
+        }
+
+        // Enable the ability to change the spell language, if applicable
+        final LocaleList localeList = LocaleList.getDefault();
+        final Locale locale = localeList.getFirstMatch(new String[]{"pt-BR", "pt-PT"});
+        final PreferenceScreen preferenceScreen = getPreferenceScreen();
+        final Preference languagePreference = preferenceScreen.findPreference(getString(R.string.spell_language_key));
+        if (languagePreference != null) {
+            if (locale.getLanguage().equals("pt")) {
+                languagePreference.setVisible(true);
+                languagePreference.setEnabled(true);
+            } else {
+                final PreferenceCategory preferenceCategory = preferenceScreen.findPreference(getString(R.string.general_layout_preferences));
+                if (preferenceCategory != null) {
+                    preferenceCategory.removePreference(languagePreference);
+                }
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/dnd/jon/spellbook/SettingsFragment.java
+++ b/app/src/main/java/dnd/jon/spellbook/SettingsFragment.java
@@ -41,11 +41,11 @@ public class SettingsFragment extends PreferenceFragmentCompat {
 
         // Enable the ability to change the spell language, if applicable
         final LocaleList localeList = LocaleList.getDefault();
-        final Locale locale = localeList.getFirstMatch(new String[]{"pt-BR", "pt-PT"});
+        final Locale ptLocale = localeList.getFirstMatch(new String[]{"pt-BR", "pt-PT"});
         final PreferenceScreen preferenceScreen = getPreferenceScreen();
         final Preference languagePreference = preferenceScreen.findPreference(getString(R.string.spell_language_key));
         if (languagePreference != null) {
-            if (locale.getLanguage().equals("pt")) {
+            if (ptLocale.getLanguage().equals("pt")) {
                 languagePreference.setVisible(true);
                 languagePreference.setEnabled(true);
             } else {

--- a/app/src/main/java/dnd/jon/spellbook/Source.java
+++ b/app/src/main/java/dnd/jon/spellbook/Source.java
@@ -17,7 +17,7 @@ public class Source implements NameDisplayable {
     private static final Map<String, Source> _codeMap = new HashMap<>();
 
     static final Source PLAYERS_HANDBOOK = new Source(R.string.phb_name, R.string.phb_code, "Player's Handbook", "PHB", true);
-    static final Source XANATHARS_GTE = new Source(R.string.xge_name,R.string.xge_code, "Xanathar's Guide to Everything", "XGE", true);
+    static final Source XANATHARS_GTE = new Source(R.string.xge_name, R.string.xge_code, "Xanathar's Guide to Everything", "XGE", true);
     static final Source SWORD_COAST_AG = new Source(R.string.scag_name,R.string.scag_code, "Sword Coast Adv. Guide", "SCAG", false);
     static final Source TASHAS_COE = new Source(R.string.tce_name, R.string.tce_code, "Tasha's Cauldron of Everything", "TCE", true);
     static final Source ACQUISITIONS_INC = new Source(R.string.ai_name, R.string.ai_code, "Acquisitions Incorporated", "AI", false);

--- a/app/src/main/java/dnd/jon/spellbook/SpellCodec.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellCodec.java
@@ -7,6 +7,7 @@ import androidx.annotation.Nullable;
 import org.json.*;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Locale;
@@ -38,11 +39,19 @@ class SpellCodec {
 
     private static final String[] COMPONENT_STRINGS = { "V", "S", "M" };
 
+    // Is there a better way to do this?
+    // It doesn't seem like it
+    private static final Map<String,Integer> concentrationPrefixMap = new HashMap<>() {{
+       put(Locale.US.getLanguage(), R.string.concentration_prefix_en);
+       put("pt", R.string.concentration_prefix_pt);
+    }};
+
     private final String concentrationPrefix;
     private final Context context;
     SpellCodec(Context context) {
+        final Locale locale = SpellbookUtils.coalesce(context.getResources().getConfiguration().getLocales().get(0), Locale.US);
         this.context = context;
-        this.concentrationPrefix = context.getString(R.string.concentration_prefix);
+        this.concentrationPrefix = context.getString(concentrationPrefixMap.getOrDefault(locale, R.string.concentration_prefix_en));
     }
 
 

--- a/app/src/main/java/dnd/jon/spellbook/SpellCodec.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellCodec.java
@@ -41,7 +41,7 @@ class SpellCodec {
 
     // Is there a better way to do this?
     // It doesn't seem like it
-    private static final Map<String,Integer> concentrationPrefixMap = new HashMap<>() {{
+    private static final Map<String,Integer> concentrationPrefixMap = new HashMap<String,Integer>() {{
        put(Locale.US.getLanguage(), R.string.concentration_prefix_en);
        put("pt", R.string.concentration_prefix_pt);
     }};

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -462,10 +462,14 @@
     <!-- Content descriptions -->
     <string name="book_background_description">Book background image</string>
 
+    <!-- Language-chooser format strings -->
+    <string name="spells_filename_language" translatable="false">Spells_%1$s.json</string>
+    <string name="concentration_prefix_en" translatable="false">Up to\u0020</string>
+    <string name="concentration_prefix_pt" translatable="false">Até\u0020</string>
+
     <!-- Miscellaneous -->
     <string name="sp" translatable="false">sp</string>
     <string name="default_str">Default</string>
     <string name="restore_default">Restore Default</string>
-    <string name="spells_filename_language" translatable="false">Spells_%1$s.json</string>
 
 </resources>

--- a/app/src/main/res/xml-sw600dp/settings_screen.xml
+++ b/app/src/main/res/xml-sw600dp/settings_screen.xml
@@ -48,6 +48,8 @@
             android:entryValues="@array/language_codes"
             android:entries="@array/language_names"
             android:defaultValue="@string/english_code"
+            android:visibility="gone"
+            android:enabled="false"
             />
 
     </androidx.preference.PreferenceCategory>

--- a/app/src/main/res/xml/settings_screen.xml
+++ b/app/src/main/res/xml/settings_screen.xml
@@ -6,7 +6,10 @@
     >
 
     <androidx.preference.PreferenceCategory
-        android:title="@string/general_layout_preferences">
+        android:title="@string/general_layout_preferences"
+        android:key="@string/general_layout_preferences"
+        >
+
 
 
 <!--        <androidx.preference.EditTextPreference-->
@@ -56,6 +59,8 @@
             android:summary="%s"
             android:entryValues="@array/language_codes"
             android:entries="@array/language_names"
+            android:visibility="gone"
+            android:enabled="false"
             />
 
         <SwitchPreference


### PR DESCRIPTION
This PR provides a temporary fix for #31. While it would be nice to allow changing the spell language without leveraging the Android language resource system, that's something that will take a bit of work and is a lower priority than homebrew spells. Additionally, whatever system is implemented will want to work with some of the infrastructure updates from the homebrew branch (such as the new structure of `Source`).

Thus, the temporary fix is to only enable this option if the user has Portuguese installed as a language; otherwise, the preference is removed from the settings screen.