### PR TITLE
Additional conditional logic for setting spell locale

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
         applicationId "dnd.jon.spellbook"
         minSdkVersion 24
         targetSdkVersion 33
-        versionCode 300300
+        versionCode 3003001
         versionName "3.3.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         signingConfig signingConfigs.release

--- a/app/src/main/java/dnd/jon/spellbook/LocalizationUtils.java
+++ b/app/src/main/java/dnd/jon/spellbook/LocalizationUtils.java
@@ -90,4 +90,11 @@ public class LocalizationUtils {
     static int[] supportedTableLayoutIDs() { return supportedIDs(supportedClasses(), tableLayoutIDs); }
     static int[] supportedSpellcastingInfoIDs() { return supportedIDs(supportedClasses(), spellcastingInfoIDs); }
 
+    // TODO: Think of a way to make this more generic for other languages
+    static boolean hasPortugueseInstalled() {
+        final LocaleList localeList = LocaleList.getDefault();
+        final Locale ptLocale = localeList.getFirstMatch(new String[]{"pt-BR", "pt-PT"});
+        return ptLocale.getLanguage().equals("pt");
+    }
+
 }

--- a/app/src/main/java/dnd/jon/spellbook/LocalizationUtils.java
+++ b/app/src/main/java/dnd/jon/spellbook/LocalizationUtils.java
@@ -57,11 +57,15 @@ public class LocalizationUtils {
     static Locale defaultSpellLocale() {
         final Locale locale = getLocale();
         final String language = locale.getLanguage();
-        if (supportedLanguages.contains(language)) {
+        if (isLanguageSupported(language)) {
             return locale;
         } else {
             return Locale.US;
         }
+    }
+
+    static boolean isLanguageSupported(String languageCode) {
+        return supportedLanguages.contains(languageCode);
     }
 
     static String getCurrentLanguage() {
@@ -90,11 +94,19 @@ public class LocalizationUtils {
     static int[] supportedTableLayoutIDs() { return supportedIDs(supportedClasses(), tableLayoutIDs); }
     static int[] supportedSpellcastingInfoIDs() { return supportedIDs(supportedClasses(), spellcastingInfoIDs); }
 
-    // TODO: Think of a way to make this more generic for other languages
-    static boolean hasPortugueseInstalled() {
+    // BCP language codes are in BCP 47 format
+    // https://appmakers.dev/bcp-47-language-codes-list/
+    static boolean hasOneInstalled(String[] bcpLanguageCodes, String languageCode) {
         final LocaleList localeList = LocaleList.getDefault();
-        final Locale ptLocale = localeList.getFirstMatch(new String[]{"pt-BR", "pt-PT"});
-        return ptLocale.getLanguage().equals("pt");
+        final Locale locale = localeList.getFirstMatch(bcpLanguageCodes);
+        return locale.getLanguage().equals(languageCode);
+    }
+    static boolean hasEnglishInstalled() {
+        return hasOneInstalled(new String[]{"en-AU", "en-GB", "en-IE", "en-US", "en-ZA"}, "en");
+    }
+
+    static boolean hasPortugueseInstalled() {
+        return hasOneInstalled(new String[]{"pt-BR", "pt-PT"}, "pt");
     }
 
 }

--- a/app/src/main/java/dnd/jon/spellbook/SettingsFragment.java
+++ b/app/src/main/java/dnd/jon/spellbook/SettingsFragment.java
@@ -40,12 +40,11 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         }
 
         // Enable the ability to change the spell language, if applicable
-        final LocaleList localeList = LocaleList.getDefault();
-        final Locale ptLocale = localeList.getFirstMatch(new String[]{"pt-BR", "pt-PT"});
+        final boolean hasPortuguese = LocalizationUtils.hasPortugueseInstalled();
         final PreferenceScreen preferenceScreen = getPreferenceScreen();
         final Preference languagePreference = preferenceScreen.findPreference(getString(R.string.spell_language_key));
         if (languagePreference != null) {
-            if (ptLocale.getLanguage().equals("pt")) {
+            if (hasPortuguese) {
                 languagePreference.setVisible(true);
                 languagePreference.setEnabled(true);
             } else {

--- a/app/src/main/java/dnd/jon/spellbook/SpellbookViewModel.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellbookViewModel.java
@@ -105,10 +105,17 @@ public class SpellbookViewModel extends ViewModel implements Filterable {
         final SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(application);
         final String spellLanguageKey = application.getString(R.string.spell_language_key);
         final String spellsLocaleString = sharedPreferences.getString(spellLanguageKey, null);
-        if (LocalizationUtils.hasPortugueseInstalled()) {
-            this.spellsLocale = spellsLocaleString == null ? LocalizationUtils.defaultSpellLocale() : new Locale(spellsLocaleString);
+
+        // This is kinda hacky; think of a more scalable way to do this?
+        // Though once the UI and spell parsing languages a
+        final boolean uninstalledLanguage = (spellsLocaleString == null) ||
+                                            (spellsLocaleString.equals("pt") && !LocalizationUtils.hasPortugueseInstalled()) ||
+                                            (spellsLocaleString.equals("en") && !LocalizationUtils.hasEnglishInstalled());
+
+        if (uninstalledLanguage || !LocalizationUtils.isLanguageSupported(spellsLocaleString)) {
+            this.spellsLocale = LocalizationUtils.defaultSpellLocale();
         } else {
-            this.spellsLocale = Locale.US;
+            this.spellsLocale = new Locale(spellsLocaleString);
         }
 
         // If we don't have an existing value for the spell language setting

--- a/app/src/main/java/dnd/jon/spellbook/SpellbookViewModel.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellbookViewModel.java
@@ -105,7 +105,11 @@ public class SpellbookViewModel extends ViewModel implements Filterable {
         final SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(application);
         final String spellLanguageKey = application.getString(R.string.spell_language_key);
         final String spellsLocaleString = sharedPreferences.getString(spellLanguageKey, null);
-        this.spellsLocale = spellsLocaleString == null ? LocalizationUtils.defaultSpellLocale() : new Locale(spellsLocaleString);
+        if (LocalizationUtils.hasPortugueseInstalled()) {
+            this.spellsLocale = spellsLocaleString == null ? LocalizationUtils.defaultSpellLocale() : new Locale(spellsLocaleString);
+        } else {
+            this.spellsLocale = Locale.US;
+        }
 
         // If we don't have an existing value for the spell language setting
         // we set the default.


### PR DESCRIPTION
This PR builds on #32 to account for some edge cases involving the user's installed languages. I actually don't think these edge cases would currently ever trigger, since I don't believe the concentration prefix codepath is ever reached, as I'm pretty sure every spell has its concentration explicitly set in the JSON. But if there are going to be safeguards, they might as well work.

This is not a very scalable setup, but that can be solved when I figure out the best way to generally separate the spell parsing features from the (Android system-managed) UI language.