### PR TITLE
Don't show higher level dialog if character doesn't have higher slots

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -345,7 +345,7 @@ public class MainActivity extends AppCompatActivity
         viewModel.currentProfile().observe(this, this::setCharacterProfile);
         viewModel.currentSpell().observe(this, this::handleSpellUpdate);
         viewModel.spellTableCurrentlyVisible().observe(this, this::onSpellTableVisibilityChange);
-        viewModel.currentToastEvent().observe(this, this::displayToastMessage);
+        viewModel.currentToastEvent().observe(this, this::displayToastMessageFromEvent);
 
     }
 
@@ -1573,7 +1573,7 @@ public class MainActivity extends AppCompatActivity
     }
 
 
-    private void displayToastMessage(Event<String> toastEvent) {
+    private void displayToastMessageFromEvent(Event<String> toastEvent) {
         final String message = toastEvent.getContentIfHandled();
         if (message != null) {
             Toast.makeText(this, message, Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/dnd/jon/spellbook/SpellWindowFragment.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellWindowFragment.java
@@ -267,6 +267,8 @@ public class SpellWindowFragment extends Fragment
         final SpellSlotStatus status = viewModel.getSpellSlotStatus();
         if (level > status.maxLevelWithAvailableSlots()) {
             viewModel.castSpell(spell);
+        } else if (!spell.getHigherLevel().isEmpty() && level == status.maxLevelWithAvailableSlots()) {
+            viewModel.castSpell(spell, level);
         } else if (spell.getHigherLevel().isEmpty()) {
             if (status.getAvailableSlots(level) == 0 && status.maxLevelWithAvailableSlots() > level) {
                 final int levelToUse = status.nextAvailableSlotLevel(level);


### PR DESCRIPTION
This PR tweaks one piece of the logic for the spell casting added in #39. The change here is that, even if a spell has higher level rules, we don't show the dialog if the character doesn't have any higher level slots - there's no point in showing the dialog with only the default option being selectable.

Note that branch is different than the one slightly above it in the if-else, as we do want to call out the level in the Toast message.