### PR TITLE
Allow filtering by royalty

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/CharacterProfile.java
+++ b/app/src/main/java/dnd/jon/spellbook/CharacterProfile.java
@@ -375,14 +375,14 @@ public class CharacterProfile extends BaseObservable implements Named, Parcelabl
         final boolean concentrationFilter = json.optBoolean(concentrationKey, true);
         final boolean notConcentrationFilter = json.optBoolean(notConcentrationKey, true);
         final JSONArray componentsJSON = json.optJSONArray(componentsFiltersKey);
-        final boolean[] componentsFilters = new boolean[]{true, true, true};
+        final boolean[] componentsFilters = new boolean[]{true, true, true, true};
         if (componentsJSON != null && componentsJSON.length() == 3) {
             for (int i = 0; i < componentsJSON.length(); ++i) {
                 componentsFilters[i] = componentsJSON.getBoolean(i);
             }
         }
         final JSONArray notComponentsJSON = json.optJSONArray(notComponentsFiltersKey);
-        final boolean[] notComponentsFilters = new boolean[]{true, true, true};
+        final boolean[] notComponentsFilters = new boolean[]{true, true, true, true};
         if (notComponentsJSON != null && notComponentsJSON.length() == 3) {
             for (int i = 0; i < notComponentsJSON.length(); ++i) {
                 notComponentsFilters[i] = notComponentsJSON.getBoolean(i);
@@ -488,14 +488,14 @@ public class CharacterProfile extends BaseObservable implements Named, Parcelabl
         final boolean concentrationFilter = json.optBoolean(concentrationKey, true);
         final boolean notConcentrationFilter = json.optBoolean(notConcentrationKey, true);
         final JSONArray componentsJSON = json.optJSONArray(componentsFiltersKey);
-        final boolean[] componentsFilters = new boolean[]{true, true, true};
+        final boolean[] componentsFilters = new boolean[]{true, true, true, true};
         if (componentsJSON != null && componentsJSON.length() == 3) {
             for (int i = 0; i < componentsJSON.length(); ++i) {
                 componentsFilters[i] = componentsJSON.getBoolean(i);
             }
         }
         final JSONArray notComponentsJSON = json.optJSONArray(notComponentsFiltersKey);
-        final boolean[] notComponentsFilters = new boolean[]{true, true, true};
+        final boolean[] notComponentsFilters = new boolean[]{true, true, true, true};
         if (notComponentsJSON != null && notComponentsJSON.length() == 3) {
             for (int i = 0; i < notComponentsJSON.length(); ++i) {
                 notComponentsFilters[i] = notComponentsJSON.getBoolean(i);

--- a/app/src/main/java/dnd/jon/spellbook/SortFilterFragment.java
+++ b/app/src/main/java/dnd/jon/spellbook/SortFilterFragment.java
@@ -309,10 +309,10 @@ public class SortFilterFragment extends Fragment {
         final ComponentsFilterLayoutBinding componentsBinding = binding.componentsFilterBlock;
 
         // Set up the bindings
-        final List<YesNoFilterViewBinding> bindings = Arrays.asList(componentsBinding.verbalFilter, componentsBinding.somaticFilter, componentsBinding.materialFilter);
-        final int[] titleIDs = new int[]{ R.string.verbal_filter_title, R.string.somatic_filter_title, R.string.material_filter_title };
-        final List<BiConsumer<SortFilterStatus,Boolean>> togglers = Arrays.asList(SortFilterStatus::toggleVerbalFilter, SortFilterStatus::toggleSomaticFilter, SortFilterStatus::toggleMaterialFilter);
-        final List<BiFunction<SortFilterStatus,Boolean,Boolean>> getters = Arrays.asList(SortFilterStatus::getVerbalFilter, SortFilterStatus::getSomaticFilter, SortFilterStatus::getMaterialFilter);
+        final List<YesNoFilterViewBinding> bindings = Arrays.asList(componentsBinding.verbalFilter, componentsBinding.somaticFilter, componentsBinding.materialFilter, componentsBinding.royaltyFilter);
+        final int[] titleIDs = new int[]{ R.string.verbal_filter_title, R.string.somatic_filter_title, R.string.material_filter_title, R.string.royalty_filter_title };
+        final List<BiConsumer<SortFilterStatus,Boolean>> togglers = Arrays.asList(SortFilterStatus::toggleVerbalFilter, SortFilterStatus::toggleSomaticFilter, SortFilterStatus::toggleMaterialFilter, SortFilterStatus::toggleRoyaltyFilter);
+        final List<BiFunction<SortFilterStatus,Boolean,Boolean>> getters = Arrays.asList(SortFilterStatus::getVerbalFilter, SortFilterStatus::getSomaticFilter, SortFilterStatus::getMaterialFilter, SortFilterStatus::getRoyaltyFilter);
         for (int i = 0; i < titleIDs.length; ++i) {
             setupYesNoBinding(bindings.get(i), titleIDs[i], getters.get(i), togglers.get(i));
         }

--- a/app/src/main/java/dnd/jon/spellbook/SortFilterStatus.java
+++ b/app/src/main/java/dnd/jon/spellbook/SortFilterStatus.java
@@ -64,6 +64,7 @@ public class SortFilterStatus extends BaseObservable implements Named, Parcelabl
     private static final int VERBAL_INDEX = 0;
     private static final int SOMATIC_INDEX = 1;
     private static final int MATERIAL_INDEX = 2;
+    private static final int ROYALTY_INDEX = 3;
 
     private String name = null;
 
@@ -86,8 +87,8 @@ public class SortFilterStatus extends BaseObservable implements Named, Parcelabl
     private boolean yesConcentration = true;
     private boolean noConcentration = true;
 
-    private boolean[] yesComponents = new boolean[]{true, true, true};
-    private boolean[] noComponents = new boolean[]{true, true, true};
+    private boolean[] yesComponents = new boolean[]{true, true, true, true};
+    private boolean[] noComponents = new boolean[]{true, true, true, true};
 
     private Collection<Source> visibleSources = Stream.of(Source.PLAYERS_HANDBOOK, Source.TASHAS_COE, Source.XANATHARS_GTE).collect(Collectors.toCollection(HashSet::new));
     private Collection<CasterClass> visibleClasses = EnumSet.allOf(CasterClass.class);
@@ -256,6 +257,7 @@ public class SortFilterStatus extends BaseObservable implements Named, Parcelabl
     boolean getVerbalFilter(boolean b) { return b ? yesComponents[VERBAL_INDEX] : noComponents[VERBAL_INDEX]; }
     boolean getSomaticFilter(boolean b) { return b ? yesComponents[SOMATIC_INDEX] : noComponents[SOMATIC_INDEX]; }
     boolean getMaterialFilter(boolean b) { return b ? yesComponents[MATERIAL_INDEX] : noComponents[MATERIAL_INDEX]; }
+    boolean getRoyaltyFilter(boolean b) { return b ? yesComponents[ROYALTY_INDEX] : noComponents[ROYALTY_INDEX]; }
     boolean[] getComponents(boolean b) { return b ? yesComponents.clone() : noComponents.clone(); }
     Collection<Source> getVisibleSources(boolean b) { return getVisibleValues(b, visibleSources, Source.values()); }
     Collection<School> getVisibleSchools(boolean b) { return getVisibleValues(b, visibleSchools, School.class); }
@@ -457,6 +459,7 @@ public class SortFilterStatus extends BaseObservable implements Named, Parcelabl
     void toggleVerbalFilter(boolean tf) { toggleFilter(tf, VERBAL_INDEX); }
     void toggleSomaticFilter(boolean tf) { toggleFilter(tf, SOMATIC_INDEX); }
     void toggleMaterialFilter(boolean tf) { toggleFilter(tf, MATERIAL_INDEX); }
+    void toggleRoyaltyFilter(boolean tf) { toggleFilter(tf, ROYALTY_INDEX); }
 
     private <T> void setVisibility(T item, Collection<T> collection, boolean tf) {
         if (tf) {
@@ -671,14 +674,14 @@ public class SortFilterStatus extends BaseObservable implements Named, Parcelabl
         status.setConcentrationFilter(true, json.optBoolean(concentrationKey, true));
         status.setConcentrationFilter(false, json.optBoolean(notConcentrationKey, true));
 
-        final boolean[] yesComponents = new boolean[3];
+        final boolean[] yesComponents = new boolean[]{true, true, true, true};
         final JSONArray componentsJSON = json.getJSONArray(componentsFiltersKey);
         for (int i = 0; i < componentsJSON.length(); i++) {
             yesComponents[i] = componentsJSON.getBoolean(i);
         }
         status.setComponents(true, yesComponents);
 
-        final boolean[] noComponents = new boolean[3];
+        final boolean[] noComponents = new boolean[]{true, true, true, true};
         final JSONArray notComponentsJSON = json.getJSONArray(notComponentsFiltersKey);
         for (int i = 0; i < notComponentsJSON.length(); i++) {
             noComponents[i] = notComponentsJSON.getBoolean(i);

--- a/app/src/main/java/dnd/jon/spellbook/SpellFilter.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellFilter.java
@@ -157,6 +157,7 @@ class SpellFilter extends Filter {
         toHide = toHide || !sortFilterStatus.getVerbalFilter(components[0]);
         toHide = toHide || !sortFilterStatus.getSomaticFilter(components[1]);
         toHide = toHide || !sortFilterStatus.getMaterialFilter(components[2]);
+        toHide = toHide || !sortFilterStatus.getRoyaltyFilter(components[3]);
         toHide = toHide || (isText && !spellName.contains(text));
         return toHide;
     }

--- a/app/src/main/res/layout/components_filter_layout.xml
+++ b/app/src/main/res/layout/components_filter_layout.xml
@@ -51,6 +51,13 @@
             android:id="@+id/material_filter"
             />
 
+        <include
+            layout="@layout/yes_no_filter_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/royalty_filter"
+            />
+
     </com.google.android.flexbox.FlexboxLayout>
 
 </LinearLayout>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -158,9 +158,6 @@
     <string name="template_components_filter_title">${components}</string>
     <string name="ritual_filter_title">Ritual</string>
     <string name="concentration_filter_title">Concentração</string>
-    <string name="template_verbal_filter_title">Verbal</string>
-    <string name="template_somatic_filter_title">Somático</string>
-    <string name="template_material_filter_title">Material</string>
     <string name="template_level_range_text">\u2264 ${spell_level} \u2264</string>
     <string name="template_casting_time_range_text">\u2264 ${other_time} \u2264</string>
     <string name="template_duration_range_text">\u2264 ${finite_duration} \u2264</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -158,6 +158,10 @@
     <string name="template_components_filter_title">${components}</string>
     <string name="ritual_filter_title">Ritual</string>
     <string name="concentration_filter_title">Concentração</string>
+    <string name="template_verbal_filter_title">${verbal}</string>
+    <string name="template_somatic_filter_title">${somatic}</string>
+    <string name="template_material_filter_title">${material}</string>
+    <string name="template_royalty_filter_title">${royalty}</string>
     <string name="template_level_range_text">\u2264 ${spell_level} \u2264</string>
     <string name="template_casting_time_range_text">\u2264 ${other_time} \u2264</string>
     <string name="template_duration_range_text">\u2264 ${finite_duration} \u2264</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,10 +158,10 @@
     <string name="template_components_filter_title">${components}</string>
     <string name="ritual_filter_title">Ritual</string>
     <string name="concentration_filter_title">Concentration</string>
-    <string name="template_verbal_filter_title" translatable="false">${verbal}</string>
-    <string name="template_somatic_filter_title" translatable="false">${somatic}</string>
-    <string name="template_material_filter_title" translatable="false">${material}</string>
-    <string name="template_royalty_filter_title" translatable="false">${royalty}</string>
+    <string name="template_verbal_filter_title">${verbal}</string>
+    <string name="template_somatic_filter_title">${somatic}</string>
+    <string name="template_material_filter_title">${material}</string>
+    <string name="template_royalty_filter_title">${royalty}</string>
     <string name="template_level_range_text">\u2264 ${spell_level} \u2264</string>
     <string name="template_casting_time_range_text">\u2264 ${other_time} \u2264</string>
     <string name="template_duration_range_text">\u2264 ${finite_duration} \u2264</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,9 +158,10 @@
     <string name="template_components_filter_title">${components}</string>
     <string name="ritual_filter_title">Ritual</string>
     <string name="concentration_filter_title">Concentration</string>
-    <string name="template_verbal_filter_title">${verbal}</string>
-    <string name="template_somatic_filter_title">${somatic}</string>
-    <string name="template_material_filter_title">${material}</string>
+    <string name="template_verbal_filter_title" translatable="false">${verbal}</string>
+    <string name="template_somatic_filter_title" translatable="false">${somatic}</string>
+    <string name="template_material_filter_title" translatable="false">${material}</string>
+    <string name="template_royalty_filter_title" translatable="false">${royalty}</string>
     <string name="template_level_range_text">\u2264 ${spell_level} \u2264</string>
     <string name="template_casting_time_range_text">\u2264 ${other_time} \u2264</string>
     <string name="template_duration_range_text">\u2264 ${finite_duration} \u2264</string>

--- a/app/src/test/java/dnd/jon/spellbook/CharacterProfileTest.java
+++ b/app/src/test/java/dnd/jon/spellbook/CharacterProfileTest.java
@@ -60,9 +60,11 @@ public class CharacterProfileTest {
         Truth.assertThat(sortFilterStatus.getVerbalFilter(true)).isTrue();
         Truth.assertThat(sortFilterStatus.getSomaticFilter(true)).isTrue();
         Truth.assertThat(sortFilterStatus.getMaterialFilter(true)).isTrue();
+        Truth.assertThat(sortFilterStatus.getRoyaltyFilter(true)).isTrue();
         Truth.assertThat(sortFilterStatus.getVerbalFilter(false)).isTrue();
         Truth.assertThat(sortFilterStatus.getSomaticFilter(false)).isTrue();
         Truth.assertThat(sortFilterStatus.getMaterialFilter(false)).isTrue();
+        Truth.assertThat(sortFilterStatus.getRoyaltyFilter(false)).isTrue();
 
         Truth.assertThat(sortFilterStatus.getVisibleCastingTimeTypes(true)).containsExactlyElementsIn(CastingTime.CastingTimeType.values());
         Truth.assertThat(sortFilterStatus.getVisibleDurationTypes(true)).containsExactlyElementsIn(Duration.DurationType.values());
@@ -147,9 +149,11 @@ public class CharacterProfileTest {
             Truth.assertThat(sortFilterStatus.getVerbalFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getSomaticFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getMaterialFilter(true)).isTrue();
+            Truth.assertThat(sortFilterStatus.getRoyaltyFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getVerbalFilter(false)).isTrue();
             Truth.assertThat(sortFilterStatus.getSomaticFilter(false)).isTrue();
             Truth.assertThat(sortFilterStatus.getMaterialFilter(false)).isTrue();
+            Truth.assertThat(sortFilterStatus.getRoyaltyFilter(false)).isTrue();
 
             Truth.assertThat(sortFilterStatus.getVisibleCastingTimeTypes(true)).containsExactlyElementsIn(CastingTime.CastingTimeType.values());
             Truth.assertThat(sortFilterStatus.getVisibleDurationTypes(true)).containsExactlyElementsIn(Duration.DurationType.values());
@@ -247,9 +251,11 @@ public class CharacterProfileTest {
             Truth.assertThat(sortFilterStatus.getVerbalFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getSomaticFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getMaterialFilter(true)).isTrue();
+            Truth.assertThat(sortFilterStatus.getRoyaltyFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getVerbalFilter(false)).isTrue();
             Truth.assertThat(sortFilterStatus.getSomaticFilter(false)).isTrue();
             Truth.assertThat(sortFilterStatus.getMaterialFilter(false)).isFalse();
+            Truth.assertThat(sortFilterStatus.getRoyaltyFilter(false)).isTrue();
 
             final Collection<CastingTime.CastingTimeType> shouldBeHiddenCTTs = Collections.singletonList(CastingTime.CastingTimeType.BONUS_ACTION);
             final Collection<CastingTime.CastingTimeType> shouldBeVisibleCTTs = SpellbookUtils.complement(shouldBeHiddenCTTs, CastingTime.CastingTimeType.values());
@@ -334,9 +340,11 @@ public class CharacterProfileTest {
             Truth.assertThat(sortFilterStatus.getVerbalFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getSomaticFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getMaterialFilter(true)).isTrue();
+            Truth.assertThat(sortFilterStatus.getRoyaltyFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getVerbalFilter(false)).isTrue();
             Truth.assertThat(sortFilterStatus.getSomaticFilter(false)).isFalse();
             Truth.assertThat(sortFilterStatus.getMaterialFilter(false)).isTrue();
+            Truth.assertThat(sortFilterStatus.getRoyaltyFilter(false)).isTrue();
 
             final Collection<CastingTime.CastingTimeType> shouldBeHiddenCTTs = Collections.singletonList(CastingTime.CastingTimeType.TIME);
             final Collection<CastingTime.CastingTimeType> shouldBeVisibleCTTs = SpellbookUtils.complement(shouldBeHiddenCTTs, CastingTime.CastingTimeType.values());
@@ -450,9 +458,11 @@ public class CharacterProfileTest {
             Truth.assertThat(sortFilterStatus.getVerbalFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getSomaticFilter(true)).isFalse();
             Truth.assertThat(sortFilterStatus.getMaterialFilter(true)).isTrue();
+            Truth.assertThat(sortFilterStatus.getRoyaltyFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getVerbalFilter(false)).isTrue();
             Truth.assertThat(sortFilterStatus.getSomaticFilter(false)).isTrue();
             Truth.assertThat(sortFilterStatus.getMaterialFilter(false)).isTrue();
+            Truth.assertThat(sortFilterStatus.getRoyaltyFilter(false)).isTrue();
 
             Truth.assertThat(sortFilterStatus.getVisibleCastingTimeTypes(true)).containsExactlyElementsIn(CastingTime.CastingTimeType.values());
             Truth.assertThat(sortFilterStatus.getVisibleCastingTimeTypes(false)).isEmpty();
@@ -537,9 +547,11 @@ public class CharacterProfileTest {
             Truth.assertThat(sortFilterStatus.getVerbalFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getSomaticFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getMaterialFilter(true)).isTrue();
+            Truth.assertThat(sortFilterStatus.getRoyaltyFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getVerbalFilter(false)).isTrue();
             Truth.assertThat(sortFilterStatus.getSomaticFilter(false)).isTrue();
             Truth.assertThat(sortFilterStatus.getMaterialFilter(false)).isTrue();
+            Truth.assertThat(sortFilterStatus.getRoyaltyFilter(false)).isTrue();
 
             final Collection<CastingTime.CastingTimeType> shouldBeHiddenCTTs = Collections.singletonList(CastingTime.CastingTimeType.BONUS_ACTION);
             final Collection<CastingTime.CastingTimeType> shouldBeVisibleCTTs = SpellbookUtils.complement(shouldBeHiddenCTTs, CastingTime.CastingTimeType.values());
@@ -643,9 +655,11 @@ public class CharacterProfileTest {
             Truth.assertThat(sortFilterStatus.getVerbalFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getSomaticFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getMaterialFilter(true)).isTrue();
+            Truth.assertThat(sortFilterStatus.getRoyaltyFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getVerbalFilter(false)).isFalse();
             Truth.assertThat(sortFilterStatus.getSomaticFilter(false)).isTrue();
             Truth.assertThat(sortFilterStatus.getMaterialFilter(false)).isTrue();
+            Truth.assertThat(sortFilterStatus.getRoyaltyFilter(false)).isTrue();
 
             Truth.assertThat(sortFilterStatus.getVisibleCastingTimeTypes(true)).containsExactlyElementsIn(CastingTime.CastingTimeType.values());
             Truth.assertThat(sortFilterStatus.getVisibleCastingTimeTypes(false)).isEmpty();
@@ -762,9 +776,11 @@ public class CharacterProfileTest {
             Truth.assertThat(sortFilterStatus.getVerbalFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getSomaticFilter(true)).isFalse();
             Truth.assertThat(sortFilterStatus.getMaterialFilter(true)).isTrue();
+            Truth.assertThat(sortFilterStatus.getRoyaltyFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getVerbalFilter(false)).isTrue();
             Truth.assertThat(sortFilterStatus.getSomaticFilter(false)).isTrue();
             Truth.assertThat(sortFilterStatus.getMaterialFilter(false)).isTrue();
+            Truth.assertThat(sortFilterStatus.getRoyaltyFilter(false)).isTrue();
 
             final Collection<CastingTime.CastingTimeType> shouldBeHiddenCTTs = Collections.singletonList(CastingTime.CastingTimeType.BONUS_ACTION);
             final Collection<CastingTime.CastingTimeType> shouldBeVisibleCTTs = SpellbookUtils.complement(shouldBeHiddenCTTs, CastingTime.CastingTimeType.values());
@@ -864,9 +880,12 @@ public class CharacterProfileTest {
             Truth.assertThat(sortFilterStatus.getVerbalFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getSomaticFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getMaterialFilter(true)).isTrue();
+            Truth.assertThat(sortFilterStatus.getRoyaltyFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getVerbalFilter(false)).isTrue();
             Truth.assertThat(sortFilterStatus.getSomaticFilter(false)).isTrue();
             Truth.assertThat(sortFilterStatus.getMaterialFilter(false)).isTrue();
+            Truth.assertThat(sortFilterStatus.getRoyaltyFilter(false)).isTrue();
+
 
         } catch (JSONException e) {
             e.printStackTrace();
@@ -973,9 +992,11 @@ public class CharacterProfileTest {
             Truth.assertThat(sortFilterStatus.getVerbalFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getSomaticFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getMaterialFilter(true)).isTrue();
+            Truth.assertThat(sortFilterStatus.getRoyaltyFilter(true)).isTrue();
             Truth.assertThat(sortFilterStatus.getVerbalFilter(false)).isFalse();
             Truth.assertThat(sortFilterStatus.getSomaticFilter(false)).isTrue();
             Truth.assertThat(sortFilterStatus.getMaterialFilter(false)).isTrue();
+            Truth.assertThat(sortFilterStatus.getRoyaltyFilter(false)).isTrue();
 
         } catch (JSONException e) {
             e.printStackTrace();


### PR DESCRIPTION
The royalty component was added a while ago, but it's not currently exposed as a filter option in the UI. There are very few spells with this component, but it may as well be an option. This PR allows filtering by royalty.