### PR TITLE
Show spell list counts

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/SpellbookViewModel.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellbookViewModel.java
@@ -75,6 +75,7 @@ public class SpellbookViewModel extends ViewModel implements Filterable {
     private final MutableLiveData<SpellFilterStatus> currentSpellFilterStatusLD;
     private final MutableLiveData<SortFilterStatus> currentSortFilterStatusLD;
     private final MutableLiveData<SpellSlotStatus> currentSpellSlotStatusLD;
+    private final MutableLiveData<Void> spellFilterEventLD;
 
     private static List<Spell> englishSpells = new ArrayList<>();
     private List<Spell> spells;
@@ -145,6 +146,7 @@ public class SpellbookViewModel extends ViewModel implements Filterable {
         this.currentSpellFilterStatusLD = new MutableLiveData<>();
         this.currentSortFilterStatusLD = new MutableLiveData<>();
         this.currentSpellSlotStatusLD = new MutableLiveData<>();
+        this.spellFilterEventLD = new MutableLiveData<>();
         this.spellsFilename = spellsContext.getResources().getString(R.string.spells_filename);
         this.spells = loadSpellsFromFile(spellsFilename, this.spellsLocale);
         this.currentSpellList = new ArrayList<>(spells);
@@ -249,6 +251,8 @@ public class SpellbookViewModel extends ViewModel implements Filterable {
     LiveData<Boolean> currentSpellFavoriteLD() { return currentSpellFavoriteLD; }
     LiveData<Boolean> currentSpellPreparedLD() { return currentSpellPreparedLD; }
     LiveData<Boolean> currentSpellKnownLD() { return currentSpellKnownLD; }
+
+    LiveData<Void> spellFilterEvent() { return spellFilterEventLD; }
 
     void setCurrentSpell(Spell spell) {
         currentSpellLD.setValue(spell);
@@ -394,10 +398,10 @@ public class SpellbookViewModel extends ViewModel implements Filterable {
         profile.addOnPropertyChangedCallback(new Observable.OnPropertyChangedCallback() {
             @Override
             public void onPropertyChanged(Observable sender, int propertyId) {
-            if (sender != profile) { return; }
-            if (propertyId == BR.sortFilterStatus) {
-                setupSortFilterObserver();
-            }
+                if (sender != profile) { return; }
+                if (propertyId == BR.sortFilterStatus) {
+                    setupSortFilterObserver();
+                }
             }
         });
     }
@@ -443,6 +447,9 @@ public class SpellbookViewModel extends ViewModel implements Filterable {
             @Override
             public void onPropertyChanged(Observable sender, int propertyId) {
                 if (sender != spellFilterStatus) { return; }
+                if (propertyId == BR.spellFilterFlag) {
+                    spellFilterEventLD.setValue(null);
+                }
                 saveSpellFilterStatus();
             }
         });

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -459,6 +459,7 @@
     <string name="bottom_nav_buttons">Botões de navegação inferior</string>
     <string name="spell_text_color">Soletrar cor do texto</string>
     <string name="fab_movable_title">Permitir movimento do botão circular</string>
+    <string name="show_spell_list_counts">Mostrar contagens da lista de feitiços</string>
 
     <!-- Locations -->
     <string name="spell_lists_location">Localização das listas de feitiços</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,6 +5,7 @@
     <color name="black">#000000</color>
     <color name="lightBrown">#FFDEAD</color>
 
+    <color name="defaultTextColor">@color/black</color>
     <!-- Original default colors
     <color name="colorPrimary">#3F51B5</color>
     <color name="colorPrimaryDark">#303F9F</color>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -4,4 +4,5 @@
     <string name="spell_slot_locations" translatable="false">spell_slot_locations</string>
     <string name="text_font_size" translatable="false">text_font_size</string>
     <string name="text_color" translatable="false">text_color</string>
+    <string name="show_list_counts" translatable="false">show_list_counts</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="update_info">Update Info</string>
     <string name="whats_new">What\'s new</string>
     <string name="settings">Settings</string>
+    <string name="name_with_count" translatable="false">%1$s (%2$s)</string>
 
     <!-- Main window labels -->
     <string name="spell_name">Spell Name</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -461,6 +461,7 @@
     <string name="bottom_nav_buttons">Bottom navigation buttons</string>
     <string name="spell_text_color">Spell text color</string>
     <string name="fab_movable_title">Allow moving circular button</string>
+    <string name="show_spell_list_counts">Show spell list counts</string>
 
     <!-- Locations -->
     <string name="spell_lists_location">Spell lists location</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -50,7 +50,7 @@
 
     <!-- Text fields in general -->
     <style name="GeneralTextStyle">
-        <item name="android:textColor">#000000</item>
+        <item name="android:textColor">@color/defaultTextColor</item>
         <item name="android:alpha">0.8</item>
     </style>
 

--- a/app/src/main/res/xml-sw600dp/settings_screen.xml
+++ b/app/src/main/res/xml-sw600dp/settings_screen.xml
@@ -52,6 +52,12 @@
             android:enabled="false"
             />
 
+        <SwitchPreference
+            android:key="@string/show_list_counts"
+            android:title="@string/show_spell_list_counts"
+            android:defaultValue="true"
+            />
+
     </androidx.preference.PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>

--- a/app/src/main/res/xml/settings_screen.xml
+++ b/app/src/main/res/xml/settings_screen.xml
@@ -59,6 +59,7 @@
             android:summary="%s"
             android:entryValues="@array/language_codes"
             android:entries="@array/language_names"
+            android:defaultValue="@string/english_code"
             android:visibility="gone"
             android:enabled="false"
             />
@@ -66,6 +67,12 @@
         <SwitchPreference
             android:key="@string/fab_movable_key"
             android:title="@string/fab_movable_title"
+            android:defaultValue="true"
+            />
+
+        <SwitchPreference
+            android:key="@string/show_list_counts"
+            android:title="@string/show_spell_list_counts"
             android:defaultValue="true"
             />
 


### PR DESCRIPTION
This PR implements a user-requested feature to show the counts of spell lists, either in the side menu or the bottom navigation bar. This is done by giving the list count after the list name (e.g. `Prepared (5)`). For people out there who don't want this, it can be enabled/disabled in the settings.