### PR TITLE
Re-filter when on a spell list after closing spell window on a phone

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -353,7 +353,7 @@ public class MainActivity extends AppCompatActivity
 
         // Define our spell list-related observers
         this.spellFilterStatusObserver = (status) -> this.updateListCounts();
-        this.spellFilterEventObserver= (nothing) -> this.updateListCounts();
+        this.spellFilterEventObserver = (nothing) -> this.updateListCounts();
         this.favoriteListCountObserver = (favorite) -> this.updateMenuFavoriteCounts();
         this.preparedListCountObserver = (prepared) -> this.updateMenuPreparedCounts();
         this.knownListCountObserver = (known) -> this.updateMenuKnownCounts();
@@ -365,7 +365,6 @@ public class MainActivity extends AppCompatActivity
         viewModel.currentSpell().observe(this, this::handleSpellUpdate);
         viewModel.spellTableCurrentlyVisible().observe(this, this::onSpellTableVisibilityChange);
         viewModel.currentToastEvent().observe(this, this::displayToastMessageFromEvent);
-
     }
 
 

--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -1277,6 +1277,12 @@ public class MainActivity extends AppCompatActivity
                 final Handler handler = new Handler();
                 // This delay matches the length of the transition animation
                 handler.postDelayed(() -> spellWindowFragment = null, getResources().getInteger(integer.transition_duration));
+
+                // If we're on one of the spell lists,
+                // then re-filter to make sure that this spell should still be there
+                if (sortFilterStatus.getStatusFilterField() != StatusFilterField.ALL) {
+                    viewModel.setFilterNeeded();
+                }
             })
             .commit();
     }


### PR DESCRIPTION
This PR implements the changes described in #58. With this change, the spell table is re-filtered after closing the spell window on a phone if the user is on one of the spell lists.

Additionally, this PR modifies the tablet behavior to match this as closely as possible. Now, when one of the spell list buttons inside of the spell window is pushed on a tablet, we immediately ask for a list filter since the list is still visible (and since the spell is still in the spell window, a user can easily correct this if it was a mistake).