### PR TITLE
Add royalty description to component info

### DIFF
--- a/app/src/main/res/values-pt/spellcasting_info.xml
+++ b/app/src/main/res/values-pt/spellcasting_info.xml
@@ -220,6 +220,29 @@
         \n\tUm conjurador precisa ter uma das mãos livres para
         ter acesso aos componentes, mas pode ser a mesma mão
         que se utiliza para executar os componentes gestuais.
+        \n\n<b>REALEZA (R)</b>
+        \nA marca exclusiva de lançamento de feitiços de Jim Darkmagic mistura arcano
+        experiência com um tipo particular de fervor pecuniário. Novo
+        feitiços originalmente desenvolvidos por Jim geraram um novo tipo de feitiço
+        componente, que desde então se espalhou para outros feitiços criados por
+        funcionários e franqueados da Acquisitions Incorporated:
+        o componente de royalties.
+        \nPara lançar um feitiço que empregue um componente de royalties (incluindo
+        usando um pergaminho mágico ou outro item mágico que armazene tal
+        magia), o conjurador deve ter fundos suficientes consigo.
+        O custo da conjuração é definido pelo conjurador que cria o
+        magia, mas normalmente custa 1 po por nível de espaço de magia. Quando o feitiço
+        é lançado, a realeza é magicamente transportada para um cofre ou outro
+        objeto designado pelo conjurador criador. Este pagamento é
+        feito se o lançador que usa o feitiço está ciente da realeza
+        componente ou não. Se o lançador não tiver fundos suficientes,
+        o feitiço não está perdido, mas não pode ser lançado.
+        \nEmbora muitos rodízios tenham tentado contornar o componente de royalties,
+        nenhum jamais teve sucesso total. No entanto, diz-se que um personagem
+        pode tentar um teste de Inteligência (Arcanismo) CD 15 enquanto lança um feitiço
+        com um componente de royalties. Com uma verificação bem-sucedida, o pagamento é cobrado
+        de uma criatura aleatória a até 3 metros do lançador, sem que
+        conhecimento da criatura.
     </string>
 
     <string name="duration_info">

--- a/app/src/main/res/values/spellcasting_info.xml
+++ b/app/src/main/res/values/spellcasting_info.xml
@@ -195,6 +195,29 @@
         \n\tA spellcaster must have a hand free to access these
         components, but it can be the same hand that he or she
         uses to perform somatic components.
+        \n\n<b>ROYALTY (R)</b>
+        \nJim Darkmagic\'s unique brand of spellcasting mixes arcane
+        expertise with a particular kind of pecuniary fervor. New
+        spells originally developed by Jim spawned a new type of spell
+        component, which has since spread to other spells created by
+        employees and franchisees of Acquisitions Incorporated:
+        the royalty component.
+        \nTo cast a spell that employs a royalty component (including
+        using a spell scroll or other magic item that stores such a
+        spell), a caster must have sufficient funds on their person.
+        The cost of the casting is set by the caster who creates the
+        spell, but is typically 1 gp per spell slot level. When the spell
+        is cast, the royalty is magically transported to a coffer or other
+        object designated by the creating spellcaster. This payment is
+        made whether the caster using the spell is aware of the royalty
+        component or not. If the caster does not have sufficient funds,
+        the spell is not lost but it cannot be cast.
+        \nThough many casters have tried to circumvent the royalty component,
+        none have ever fully succeeded. However, it is said that a character
+        can attempt a DC 15 Intelligence (Arcana) check while casting a spell
+        with a royalty component. With a successful check, the payment is taken
+        from a random creature within 10 feet of the caster, without that
+        creature\'s knowledge.
     </string>
 
     <string name="duration_info">


### PR DESCRIPTION
A user noted that the component section of the spellcasting info didn't have a description of the royalty component, so this PR adds that in.