### PR TITLE
Don't include empty component descriptions in spell export

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/BaseSpellListExporter.java
+++ b/app/src/main/java/dnd/jon/spellbook/BaseSpellListExporter.java
@@ -76,10 +76,14 @@ public abstract class BaseSpellListExporter implements SpellListExporter {
             final String componentsPrompt = DisplayUtils.componentsPrompt(context);
             addPromptText(componentsPrompt, spell.componentsString());
             addLineBreak();
-            addPromptText(DisplayUtils.materialsPrompt(context), spell.getMaterial());
-            addLineBreak();
-            addPromptText(DisplayUtils.rangePrompt(context), spell.getRoyalty());
-            addLineBreak();
+            if (!spell.getMaterial().isEmpty()) {
+                addPromptText(DisplayUtils.materialsPrompt(context), spell.getMaterial());
+                addLineBreak();
+            }
+            if (!spell.getRoyalty().isEmpty()) {
+                addPromptText(DisplayUtils.royaltyPrompt(context), spell.getRoyalty());
+                addLineBreak();
+            }
             final String durationPrompt = DisplayUtils.durationPrompt(context);
             final String durationText = DisplayUtils.string(context, spell.getDuration());
             addPromptText(durationPrompt, durationText);

--- a/app/src/main/res/values/spellcasting_info.xml
+++ b/app/src/main/res/values/spellcasting_info.xml
@@ -165,7 +165,7 @@
         A spell\'s components are the physical requirements you
         must meet in order to cast it. Each spell\'s description
         indicates whether it requires verbal (V), somatic (S),
-        or material (M) components. If you can\'t provide one
+        material (M), or royalty (R) components. If you can\'t provide one
         or more of a spell\'s components, you are unable to
         cast the spell.
         \n\n<b>VERBAL (V)</b>


### PR DESCRIPTION
One thing that was overlooked in #64 was that we don't want to include the materials and royalty fields in the text for exported spells if they're empty (just like what we do in the spell display fragment). This PR fixes that, as well as correcting the fact that the incorrect prompt was accidentally used for the royalty description, and slightly tweaking the component info text.