### PR TITLE
Serialize spells to JSON using Locale-aware context

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/DisplayUtils.java
+++ b/app/src/main/java/dnd/jon/spellbook/DisplayUtils.java
@@ -7,8 +7,6 @@ import java.text.DecimalFormat;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Objects;
-import java.util.SortedSet;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.ToIntFunction;

--- a/app/src/main/java/dnd/jon/spellbook/SpellCodec.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellCodec.java
@@ -39,11 +39,11 @@ class SpellCodec {
 
     private static final String[] COMPONENT_STRINGS = { "V", "S", "M" };
 
-    // Is there a better way to do this?
+    // TODO: Is there a better way to do this?
     // It doesn't seem like it
-    private static final Map<String,Integer> concentrationPrefixMap = new HashMap<String,Integer>() {{
-       put(Locale.US.getLanguage(), R.string.concentration_prefix_en);
-       put("pt", R.string.concentration_prefix_pt);
+    private static final Map<String,Integer> concentrationPrefixMap = new HashMap<>() {{
+        put(Locale.US.getLanguage(), R.string.concentration_prefix_en);
+        put("pt", R.string.concentration_prefix_pt);
     }};
 
     private final String concentrationPrefix;
@@ -184,7 +184,7 @@ class SpellCodec {
         return parseSpellList(jsonArray, false, LocalizationUtils.getLocale());
     }
 
-    JSONObject toJSON(Spell spell) throws JSONException {
+    JSONObject toJSON(Spell spell, Context context) throws JSONException {
 
         final JSONObject json = new JSONObject();
 
@@ -192,15 +192,15 @@ class SpellCodec {
         json.put(NAME_KEY, spell.getName());
         json.put(DESCRIPTION_KEY, spell.getDescription());
         json.put(HIGHER_LEVEL_KEY, spell.getHigherLevel());
-        json.put(RANGE_KEY, spell.getRange().internalString());
+        json.put(RANGE_KEY, DisplayUtils.string(context, spell.getRange()));
         json.put(MATERIAL_KEY, spell.getMaterial());
         json.put(ROYALTY_KEY, spell.getRoyalty());
         json.put(RITUAL_KEY, spell.getRitual());
-        json.put(DURATION_KEY, spell.getDuration().internalString());
+        json.put(DURATION_KEY, DisplayUtils.string(context, spell.getDuration()));
         json.put(CONCENTRATION_KEY, spell.getConcentration());
-        json.put(CASTING_TIME_KEY, spell.getCastingTime().internalString());
+        json.put(CASTING_TIME_KEY, DisplayUtils.string(context, spell.getCastingTime()));
         json.put(LEVEL_KEY, spell.getLevel());
-        json.put(SCHOOL_KEY, spell.getSchool().getInternalName());
+        json.put(SCHOOL_KEY, context.getString(spell.getSchool().getDisplayNameID()));
 
         int i = 0;
         final JSONArray locations = new JSONArray();
@@ -224,7 +224,7 @@ class SpellCodec {
         JSONArray classes = new JSONArray();
         Collection<CasterClass> spellClasses = spell.getClasses();
         for (CasterClass cc : spellClasses) {
-            classes.put(cc.getInternalName());
+            classes.put(DisplayUtils.getDisplayName(context, cc));
         }
         json.put(CLASSES_KEY, classes);
 
@@ -238,7 +238,7 @@ class SpellCodec {
         JSONArray expandedClasses = new JSONArray();
         Collection<CasterClass> spellExpandedClasses = spell.getTashasExpandedClasses();
         for (CasterClass cc : spellExpandedClasses) {
-            expandedClasses.put(cc.getInternalName());
+            expandedClasses.put(DisplayUtils.getDisplayName(context, cc));
         }
         json.put(TCE_EXPANDED_CLASSES_KEY, expandedClasses);
 

--- a/app/src/main/java/dnd/jon/spellbook/SpellbookViewModel.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellbookViewModel.java
@@ -774,7 +774,7 @@ public class SpellbookViewModel extends ViewModel implements Filterable {
     boolean saveCreatedSpell(Spell spell) {
         final String filename = spell.getName() + CREATED_SPELL_EXTENSION;
         final File filepath = new File(createdSpellsDir, filename);
-        return JSONUtils.saveAsJSON(spell, spellCodec::toJSON, filepath);
+        return JSONUtils.saveAsJSON(spell, (s) -> spellCodec.toJSON(s, getContext()), filepath);
     }
 
     void updateSpell(Spell oldSpell, Spell newSpell) {

--- a/app/src/main/res/layout/spell_creation.xml
+++ b/app/src/main/res/layout/spell_creation.xml
@@ -67,6 +67,7 @@
                     android:hint="@string/spell_creation_name_hint"
                     android:autofillHints="@string/spell_creation_name_autofill_hints"
                     android:background="@android:color/transparent"
+                    android:layout_marginStart="5dp"
                     />
 
             </LinearLayout>


### PR DESCRIPTION
This PR modifies the spell codec to serialize spells to JSON using the application `Context` (which is `Locale`-aware). It's this `Context` object that's used for the JSON spell parsing, so we should use the same one both ways. Currently the US `Locale` is used, which causes homebrew spells to be not parse in the Portuguese version. This hasn't come up until now because the only time that we serialize spells to JSON is when saving homebrew spells, and that's a new feature that hasn't been released yet. Additionally, this PR also make a couple of other (unrelated) minor changes.