### PR TITLE
Retain certain quantity constructors in release mode

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -27,3 +27,7 @@
 -keepclassmembers class dnd.jon.spellbook.* implements Unit {
     static * fromString(java.lang.String);
 }
+
+-keepclassmembers class dnd.jon.spellbook.* implements Quantity {
+    public <init>(...);
+}

--- a/app/src/main/java/dnd/jon/spellbook/CastingTime.java
+++ b/app/src/main/java/dnd/jon/spellbook/CastingTime.java
@@ -65,10 +65,12 @@ public class CastingTime extends Quantity<CastingTime.CastingTimeType, TimeUnit>
     private static final int SECONDS_PER_ROUND = 6;
 
     // Convenience constructors
-    CastingTime(CastingTimeType type, float value, TimeUnit unit, String str) { super(type, value, unit, str); }
+    @Keep
+    public CastingTime(CastingTimeType type, float value, TimeUnit unit, String str) { super(type, value, unit, str); }
     CastingTime(CastingTimeType type, float value, TimeUnit unit) { super(type, value, unit); }
     CastingTime(CastingTimeType type, float value) { super(type, value, TimeUnit.SECOND); }
-    CastingTime(CastingTimeType type) { this(type, 1); }
+    @Keep
+    public CastingTime(CastingTimeType type) { this(type, 1); }
     CastingTime() { this(CastingTimeType.ACTION, 1, TimeUnit.SECOND, ""); }
 
     // For Parcelable

--- a/app/src/main/java/dnd/jon/spellbook/Duration.java
+++ b/app/src/main/java/dnd/jon/spellbook/Duration.java
@@ -50,10 +50,12 @@ public class Duration extends Quantity<Duration.DurationType, TimeUnit> {
     }
 
     // Convenience constructors
-    Duration(DurationType type, float value, TimeUnit unit, String str) { super(type, value, unit, str); }
+    @Keep
+    public Duration(DurationType type, float value, TimeUnit unit, String str) { super(type, value, unit, str); }
     Duration(DurationType type, float value, TimeUnit unit) { super(type, value, unit); }
     Duration(DurationType type, float value) { super(type, value, TimeUnit.SECOND); }
-    Duration(DurationType type) { this(type, 0); }
+    @Keep
+    public Duration(DurationType type) { this(type, 0); }
     Duration() { this(DurationType.INSTANTANEOUS, 0, TimeUnit.SECOND, ""); }
 
     // For Parcelable

--- a/app/src/main/java/dnd/jon/spellbook/Range.java
+++ b/app/src/main/java/dnd/jon/spellbook/Range.java
@@ -52,7 +52,7 @@ public class Range extends Quantity<Range.RangeType, LengthUnit> {
 
     // Convenience constructors
     @Keep
-    Range(RangeType type, float value, LengthUnit unit, String str) {
+    public Range(RangeType type, float value, LengthUnit unit, String str) {
         super(type, value, unit, str);
     }
     Range(RangeType type, float value, LengthUnit unit) { super(type, value, unit); }
@@ -60,7 +60,7 @@ public class Range extends Quantity<Range.RangeType, LengthUnit> {
         super(type, length, LengthUnit.FOOT);
     }
     @Keep
-    Range(RangeType type) {
+    public Range(RangeType type) {
         this(type, 0);
     }
     Range() {

--- a/app/src/main/java/dnd/jon/spellbook/Range.java
+++ b/app/src/main/java/dnd/jon/spellbook/Range.java
@@ -51,6 +51,7 @@ public class Range extends Quantity<Range.RangeType, LengthUnit> {
     }
 
     // Convenience constructors
+    @Keep
     Range(RangeType type, float value, LengthUnit unit, String str) {
         super(type, value, unit, str);
     }
@@ -58,6 +59,7 @@ public class Range extends Quantity<Range.RangeType, LengthUnit> {
     Range(RangeType type, float length) {
         super(type, length, LengthUnit.FOOT);
     }
+    @Keep
     Range(RangeType type) {
         this(type, 0);
     }


### PR DESCRIPTION
During the process of homebrew spell creation, we loop over our three main quantity types (`Duration`, `CastingTime`, and `Range`), and use the current state of the view together to create each spell quantity. This involves using type variables and then dynamically looking up the appropriate constructor - not the greatest approach, but otherwise we're writing the same loop three times. Currently, however, this only works in debug mode - this PR updates the build setup so that this works in release mode too.