### PR TITLE
Allow deleting a spell on a tablet

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/SpellCreationDialog.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellCreationDialog.java
@@ -5,6 +5,7 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.View;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
@@ -15,6 +16,7 @@ import dnd.jon.spellbook.databinding.SpellCreationBinding;
 
 public class SpellCreationDialog extends DialogFragment {
     private static final String TAG = "SpellCreationDialog";
+    private static final String DELETE_SPELL_DIALOG_TAG = "DeleteSpellDialog";
     private static final String SPELL_KEY = "spell";
     private SpellbookViewModel viewModel;
     private SpellCreationHandler handler;
@@ -38,11 +40,23 @@ public class SpellCreationDialog extends DialogFragment {
 
         final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
         final LayoutInflater inflater = getLayoutInflater();
-        final SpellCreationBinding binding  = SpellCreationBinding.inflate(inflater);
+        final SpellCreationBinding binding = SpellCreationBinding.inflate(inflater);
         handler = new SpellCreationHandler(activity, binding, TAG, spell);
         handler.setOnSpellCreated(this::dismiss);
         handler.setup();
         builder.setView(binding.getRoot());
+        if (spell != null && spell.equals(editingSpell)) {
+            binding.deleteSpellButton.setVisibility(View.VISIBLE);
+            final Spell spellToDelete = spell;
+            binding.deleteSpellButton.setOnClickListener(v -> {
+                final DeleteSpellDialog dialog = new DeleteSpellDialog();
+                dialog.setOnConfirm(this::dismiss);
+                final Bundle args = new Bundle();
+                args.putString(DeleteSpellDialog.NAME_KEY, spellToDelete.getName());
+                dialog.setArguments(args);
+                dialog.show(activity.getSupportFragmentManager(), DELETE_SPELL_DIALOG_TAG);
+            });
+        }
         viewModel.currentEditingSpell().observe(requireActivity(), (newSpell) -> {
             if (newSpell != null) {
                 handler.setSpellInfo(newSpell);

--- a/app/src/main/res/layout/spell_creation.xml
+++ b/app/src/main/res/layout/spell_creation.xml
@@ -35,6 +35,17 @@
                 android:textAlignment="center"
                 android:textSize="40sp" />
 
+            <Button
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/delete_spell_button"
+                android:text="@string/delete_spell"
+                android:background="@android:color/transparent"
+                android:foreground="?android:attr/selectableItemBackground"
+                android:layout_gravity="center"
+                android:visibility="gone"
+                />
+
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -234,6 +234,7 @@
     <string name="spell_creation_higher_level_hint">Insira uma descrição de nível superior, se aplicável</string>
     <string name="spell_creation_higher_level_autofill_hints">Insira uma descrição de nível superior</string>
     <string name="create_spell">Criar Magia</string>
+    <string name="delete_spell">Excluir Magia</string>
     <string name="other_time_equals">Outra Hora = </string>
     <string name="finite_duration_equals">Duração Finita = </string>
     <string name="finite_range_equals">Alcance Finita = </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -235,6 +235,7 @@
     <string name="spell_creation_higher_level_hint">Enter higher level description, if applicable</string>
     <string name="spell_creation_higher_level_autofill_hints">Enter higher level description</string>
     <string name="create_spell">Create Spell</string>
+    <string name="delete_spell">Delete Spell</string>
     <string name="other_time_equals">Other Time = </string>
     <string name="finite_duration_equals">Finite Duration = </string>
     <string name="finite_range_equals">Finite Range = </string>


### PR DESCRIPTION
Currently the homebrew spell system has a major oversight, which is that it's impossible to delete a homebrew spell on a tablet. On a phone this is done via an action bar item, but this never shows up on a tablet since we do spell creation in a dialog rather than a fragment. This PR remedies the problem by adding a button to the dialog that allows deleting a spell. This button only appears if the dialog is for editing an existing spell, since it doesn't sense when the spell is first being created.