### PR TITLE
Only allow levels up to 9 in homebrew level text field

### DIFF
--- a/app/src/main/res/layout/spell_creation.xml
+++ b/app/src/main/res/layout/spell_creation.xml
@@ -161,6 +161,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:id="@+id/level_entry"
+                    android:maxLength="1"
                     />
 
             </LinearLayout>


### PR DESCRIPTION
This PR fixes an issue where any number can be put in for the level of a homebrew spell, whereas we want to cap the level to be between 0-9. To fix this, we set a max length of 1 on the homebrew level text field. Note that this is the same approach used for the level filtering inputs.