### PR TITLE
Fix material and royalty issues with homebrew spells

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/SpellCodec.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellCodec.java
@@ -37,7 +37,7 @@ class SpellCodec {
     private static final String SOURCEBOOK_KEY = "sourcebook";
     private static final String LOCATIONS_KEY = "locations";
 
-    private static final String[] COMPONENT_STRINGS = { "V", "S", "M" };
+    private static final String[] COMPONENT_STRINGS = { "V", "S", "M", "R" };
 
     // TODO: Is there a better way to do this?
     // It doesn't seem like it

--- a/app/src/main/java/dnd/jon/spellbook/SpellCreationHandler.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellCreationHandler.java
@@ -406,6 +406,13 @@ public class SpellCreationHandler {
             spellBuilder.addLocation(source, -1);
         }
 
+        if (materialChecked) {
+            spellBuilder.setMaterial(materialsString);
+        }
+        if (royaltyChecked) {
+            spellBuilder.setRoyalty(royaltyString);
+        }
+
         final Spell newSpell = spellBuilder.build();
         if (spell == null) {
             // Tell the ViewModel about the new spell


### PR DESCRIPTION
This PR fixes a couple of errors related to spell creation:
* Currently we don't actually use the material and royalty text that a user inputs - I just forgot to actually give them to the spell builder. This PR fixes that.
* This PR fixes a small issue where spells with royalty components could not be properly serialized.