### PR TITLE
Fix material and royalty issues with homebrew spells, part 2

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/SpellCreationHandler.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellCreationHandler.java
@@ -256,6 +256,8 @@ public class SpellCreationHandler {
         binding.somaticCheckbox.setChecked(components[1]);
         binding.materialCheckbox.setChecked(components[2]);
         binding.royaltyCheckbox.setChecked(components[3]);
+        binding.materialsEntry.setText(spell.getMaterial());
+        binding.royaltyEntry.setText(spell.getRoyalty());
     }
 
     private void showErrorMessage(String text) {


### PR DESCRIPTION
This PR fixes the flip side of the issue from #79 - this time, we're correctly populating the materials and royalty text fields.