### PR TITLE
Version 4.0.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "dnd.jon.spellbook"
         minSdkVersion 24
         targetSdkVersion 33
-        versionCode 4000000
-        versionName "4.0.0"
+        versionCode 4000001
+        versionName "4.0.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         signingConfig signingConfigs.release
     }

--- a/app/src/main/java/dnd/jon/spellbook/GlobalInfo.java
+++ b/app/src/main/java/dnd/jon/spellbook/GlobalInfo.java
@@ -2,7 +2,7 @@ package dnd.jon.spellbook;
 
 class GlobalInfo {
 
-    static final Version VERSION = new Version(4,0,0);
+    static final Version VERSION = new Version(4,0,1);
     static final String VERSION_CODE = VERSION.string();
 
     // We don't always want to show an update message

--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -831,9 +831,13 @@ public class MainActivity extends AppCompatActivity
         if (onTablet || binding.fab == null) { return; }
         binding.fab.setOnClickListener((v) -> {
             openedSpellSlotsFromFAB = true;
-            fabCenterReveal = new CenterReveal(binding.fab, null);
-            //fabCenterReveal = new CenterReveal(binding.fab, binding.phoneFragmentContainer);
-            fabCenterReveal.start(() -> globalNavigateTo(id.spellSlotManagerFragment));
+            try {
+                fabCenterReveal = new CenterReveal(binding.fab, null);
+                //fabCenterReveal = new CenterReveal(binding.fab, binding.phoneFragmentContainer);
+                fabCenterReveal.start(() -> globalNavigateTo(id.spellSlotManagerFragment));
+            } catch (Exception e) {
+                globalNavigateTo(id.spellSlotManagerFragment);
+            }
         });
     }
 
@@ -1188,7 +1192,11 @@ public class MainActivity extends AppCompatActivity
             if (fabCenterReveal == null) {
                 fabCenterReveal = new CenterReveal(binding.fab, null);
             }
-            fabCenterReveal.reverse(null);
+            try {
+                fabCenterReveal.reverse(null);
+            } catch (Exception e) {
+                binding.fab.resetPosition();
+            }
             openedSpellSlotsFromFAB = false;
         }
     }

--- a/app/src/main/java/dnd/jon/spellbook/MovableFloatingActionButton.java
+++ b/app/src/main/java/dnd/jon/spellbook/MovableFloatingActionButton.java
@@ -48,13 +48,20 @@ public class MovableFloatingActionButton extends FloatingActionButton implements
 
     }
 
+    public void resetPosition() {
+        if (initialX != null && initialY != null) {
+            this.setX(initialX);
+            this.setY(initialY);
+        }
+    }
+
     public void setMovable(boolean movable) {
         this.movable = movable;
 
+
         // If not movable, reset to the initial position
-        if (!movable && initialX != null && initialY != null) {
-            this.setX(initialX);
-            this.setY(initialY);
+        if (!movable) {
+            resetPosition();
         }
     }
 

--- a/app/src/main/res/layout/spell_slot_manager.xml
+++ b/app/src/main/res/layout/spell_slot_manager.xml
@@ -81,6 +81,8 @@
                 android:id="@+id/spell_slots_recycler"
                 android:nestedScrollingEnabled="false"
                 android:layout_centerHorizontal="true"
+                android:clipToPadding="false"
+                android:paddingBottom="60dp"
                 />
 
         </RelativeLayout>


### PR DESCRIPTION
This PR contains updates for version 4.0.1, a bugfix update that makes the following changes:
* Adds some padding to the bottom of the spell slots `RecyclerView` to fix an issue where the bottom spell slot row could be unreachable on smaller phones
* Attempt to fix an issue (noticed from crash reports) with the FAB center reveal when opening the spell slots window that seems to happen on some phones