### PR TITLE
Fix animation bug on some phones

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "dnd.jon.spellbook"
         minSdkVersion 24
         targetSdkVersion 33
-        versionCode 4000001
-        versionName "4.0.1"
+        versionCode 4000002
+        versionName "4.0.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         signingConfig signingConfigs.release
     }

--- a/app/src/main/java/dnd/jon/spellbook/CenterReveal.java
+++ b/app/src/main/java/dnd/jon/spellbook/CenterReveal.java
@@ -30,7 +30,7 @@ public class CenterReveal {
                 PropertyValuesHolder.ofFloat(View.TRANSLATION_Y, cY)
         );
         viewAlpha = ObjectAnimator.ofFloat(view, View.ALPHA, 0f);
-        containerAlpha = ObjectAnimator.ofFloat(container, View.ALPHA, 0f, 1f);
+        containerAlpha = container != null ? ObjectAnimator.ofFloat(container, View.ALPHA, 0f, 1f) : null;
         viewScale = ObjectAnimator.ofPropertyValuesHolder(view,
                 PropertyValuesHolder.ofFloat(View.SCALE_X, 10f),
                 PropertyValuesHolder.ofFloat(View.SCALE_Y, 10f)
@@ -82,7 +82,11 @@ public class CenterReveal {
 
         final AnimatorSet secondAnimatorSet = new AnimatorSet();
         secondAnimatorSet.setDuration(duration);
-        secondAnimatorSet.playTogether(viewAlpha, viewScale, containerAlpha);
+        if (containerAlpha != null) {
+            secondAnimatorSet.playTogether(viewAlpha, viewScale, containerAlpha);
+        } else {
+            secondAnimatorSet.playTogether(viewAlpha, viewScale);
+        }
 
         final AnimatorSet animatorSet = new AnimatorSet();
         animatorSet.playSequentially(firstAnimatorSet, secondAnimatorSet);
@@ -162,7 +166,9 @@ public class CenterReveal {
         });
         viewScale.setDuration(duration).reverse();
         viewAlpha.setDuration(duration).reverse();
-        containerAlpha.setDuration(duration).reverse();
+        if (containerAlpha != null) {
+            containerAlpha.setDuration(duration).reverse();
+        }
     }
 
 }

--- a/app/src/main/java/dnd/jon/spellbook/GlobalInfo.java
+++ b/app/src/main/java/dnd/jon/spellbook/GlobalInfo.java
@@ -2,7 +2,7 @@ package dnd.jon.spellbook;
 
 class GlobalInfo {
 
-    static final Version VERSION = new Version(4,0,1);
+    static final Version VERSION = new Version(4,0,2);
     static final String VERSION_CODE = VERSION.string();
 
     // We don't always want to show an update message

--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -833,7 +833,6 @@ public class MainActivity extends AppCompatActivity
             openedSpellSlotsFromFAB = true;
             try {
                 fabCenterReveal = new CenterReveal(binding.fab, null);
-                //fabCenterReveal = new CenterReveal(binding.fab, binding.phoneFragmentContainer);
                 fabCenterReveal.start(() -> globalNavigateTo(id.spellSlotManagerFragment));
             } catch (Exception e) {
                 globalNavigateTo(id.spellSlotManagerFragment);


### PR DESCRIPTION
This PR adds some null handing to the `CenterReveal` for the floating action button. This fixes a bug that could cause crashes on some phone models. In particular, it seemed to be an issue mostly for Pixel Xa phones (Pixel 6a, 7a, 8a, etc.).

This PR also bumps the version info for the next version, 4.0.2.