### PR TITLE
Use current min/max levels for parsing fallbacks

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/SortFilterFragment.java
+++ b/app/src/main/java/dnd/jon/spellbook/SortFilterFragment.java
@@ -242,7 +242,8 @@ public class SortFilterFragment extends SpellbookFragment<SortFilterLayoutBindin
                     level = Integer.parseInt(tv.getText().toString());
                 } catch (NumberFormatException | NullPointerException e) {
                     e.printStackTrace();
-                    tv.setText(formattedInteger(Spellbook.MIN_SPELL_LEVEL));
+                    level = viewModel.getSortFilterStatus() != null ? viewModel.getSortFilterStatus().getMinSpellLevel() : Spellbook.MIN_SPELL_LEVEL;
+                    tv.setText(formattedInteger(level));
                     return;
                 }
                 viewModel.getSortFilterStatus().setMinSpellLevel(level);
@@ -258,7 +259,8 @@ public class SortFilterFragment extends SpellbookFragment<SortFilterLayoutBindin
                     level = Integer.parseInt(tv.getText().toString());
                 } catch (NumberFormatException | NullPointerException e) {
                     e.printStackTrace();
-                    tv.setText(formattedInteger(Spellbook.MAX_SPELL_LEVEL));
+                    level = viewModel.getSortFilterStatus() != null ? viewModel.getSortFilterStatus().getMaxSpellLevel() : Spellbook.MAX_SPELL_LEVEL;
+                    tv.setText(formattedInteger(level));
                     return;
                 }
                 viewModel.getSortFilterStatus().setMaxSpellLevel(level);


### PR DESCRIPTION
This PR updates the fallback behavior for the text parsing of the level text entries. Currently we use the global `Spellbook.MIN_SPELL_LEVEL`/`Spellbook.MAX_SPELL_LEVEL` values, but it makes more sense to use the values for the current character profile, which this PR does.