### PR TITLE
Add Protection from Evil and Good to expanded Druid list

### DIFF
--- a/app/src/main/assets/Spells_en.json
+++ b/app/src/main/assets/Spells_en.json
@@ -8448,6 +8448,9 @@
         "subclasses": [
             "Lore",
             "Devotion"
+        ],
+        "tce_expanded_classes":  [
+            "Druid"
         ]
     },
     {

--- a/app/src/main/assets/Spells_pt.json
+++ b/app/src/main/assets/Spells_pt.json
@@ -10967,7 +10967,10 @@
         "name": "Proteção contra o Bem e Mal",
         "range": "Toque",
         "ritual": false,
-        "school": "Abjuração"
+        "school": "Abjuração",
+        "tce_expanded_classes":  [
+            "Druida"
+        ]
     },
     {
         "casting_time": "1 ação",


### PR DESCRIPTION
In the app, Protection from Evil and Good is currently missing from the expanded Druid spell list (from Tasha's Cauldron of Everything). This PR fixes that.