### PR TITLE
Adjust tablet logic for bottom nav display

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "dnd.jon.spellbook"
         minSdkVersion 24
         targetSdkVersion 33
-        versionCode 4000003
-        versionName "4.0.3"
+        versionCode 4000004
+        versionName "4.0.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         signingConfig signingConfigs.release
     }

--- a/app/src/main/java/dnd/jon/spellbook/GlobalInfo.java
+++ b/app/src/main/java/dnd/jon/spellbook/GlobalInfo.java
@@ -2,7 +2,7 @@ package dnd.jon.spellbook;
 
 class GlobalInfo {
 
-    static final Version VERSION = new Version(4,0,3);
+    static final Version VERSION = new Version(4,0,4);
     static final String VERSION_CODE = VERSION.string();
 
     // We don't always want to show an update message

--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -1160,7 +1160,6 @@ public class MainActivity extends AppCompatActivity
     }
 
     private void updateSpellSlotMenuVisibility() {
-        if (onTablet) { return; }
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
         final String fab = getString(string.circular_button);
         final String locationsKey = getString(string.spell_slot_locations);
@@ -1383,7 +1382,8 @@ public class MainActivity extends AppCompatActivity
         boolean visible = !locationOption.equals(sideDrawer);
         if (!visible) { return false; }
         if (onTablet) {
-            return destination.getId() == id.sortFilterFragment;
+            final int destinationId = destination.getId();
+            return baseFragments.contains(destinationId);
         } else {
             return destination.getId() == id.spellTableFragment;
         }

--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -1151,7 +1151,6 @@ public class MainActivity extends AppCompatActivity
         final String bottomNav = getResources().getString(string.bottom_navbar);
         final String locationsKey = getString(string.spell_list_locations);
         final String locationsOption = prefs.getString(locationsKey, bottomNav);
-        System.out.println(locationsOption);
         final boolean visible = !locationsOption.equals(bottomNav);
         final Menu menu = navView.getMenu();
         final int[] ids = { id.nav_all, id.nav_favorites, id.nav_prepared, id.nav_known };
@@ -1397,6 +1396,7 @@ public class MainActivity extends AppCompatActivity
         bottomNavBar.setOnItemSelectedListener(item -> {
             final int id = item.getItemId();
             final SortFilterStatus sortFilterStatus = viewModel.getSortFilterStatus();
+            if (sortFilterStatus == null) { return true; }
             StatusFilterField statusFilterField;
             if (id == R.id.action_select_favorites) {
                 statusFilterField = StatusFilterField.FAVORITES;

--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -1176,6 +1176,7 @@ public class MainActivity extends AppCompatActivity
     }
 
     private void updateFABVisibility(NavDestination destination) {
+        if (destination == null) { return; }
         final int destinationId = destination.getId();
         if (onTablet || binding.fab == null) { return; }
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);


### PR DESCRIPTION
This PR updates the logic for when the bottom nav bar is displayed on a tablet, provided that it's one of the selected spell list locations in the app settings.

Additionally, this PR:
* Adds a few additional null checks in UI methods
* Bumps the version info for version 4.0.4