### PR TITLE
Add another null check to attempt to solve crash issues

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/SortFilterFragment.java
+++ b/app/src/main/java/dnd/jon/spellbook/SortFilterFragment.java
@@ -278,6 +278,9 @@ public class SortFilterFragment extends SpellbookFragment<SortFilterLayoutBindin
         restoreFullButton.setOnClickListener((v) -> {
             binding.levelFilterRange.minLevelEntry.setText(formattedInteger(Spellbook.MIN_SPELL_LEVEL));
             binding.levelFilterRange.maxLevelEntry.setText(formattedInteger(Spellbook.MAX_SPELL_LEVEL));
+            if (viewModel == null) {
+                return;
+            }
             final SortFilterStatus sortFilterStatus = viewModel.getSortFilterStatus();
             if (sortFilterStatus != null) {
                 sortFilterStatus.setMinSpellLevel(Spellbook.MIN_SPELL_LEVEL);


### PR DESCRIPTION
This PR is intended to try and solve a NPE error that that can pop up on some devices when setting up the sort/filter screen. I haven't been able to reproduce this, and so this is somewhat of a guess of where the crash might be is based on (obfuscated) crash reports. But a null check never hurt anyone, and this isn't inside of a loop or anything, so no reason not to give it a shot.