### PR TITLE
Make hide duplicates respect search text options

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -1287,7 +1287,8 @@ public class MainActivity extends AppCompatActivity
         if (onTablet || spell == null) { return; }
         final Bundle args = new Bundle();
         args.putParcelable(SpellWindowFragment.SPELL_KEY, spell);
-        args.putBoolean(SpellWindowFragment.USE_EXPANDED_KEY, viewModel.getUseExpanded());
+        final boolean useExpanded = viewModel != null && viewModel.getUseExpanded();
+        args.putBoolean(SpellWindowFragment.USE_EXPANDED_KEY, useExpanded);
         final FragmentTransaction transaction = getSupportFragmentManager()
             .beginTransaction()
             .setCustomAnimations(anim.right_to_left_enter, anim.identity);

--- a/app/src/main/java/dnd/jon/spellbook/SortFilterFragment.java
+++ b/app/src/main/java/dnd/jon/spellbook/SortFilterFragment.java
@@ -217,8 +217,12 @@ public class SortFilterFragment extends SpellbookFragment<SortFilterLayoutBindin
         filterOptions.filterSearchLayout.optionChooser.setOnCheckedChangeListener((chooser, isChecked) -> sortFilterStatus.setApplyFiltersToSearch(isChecked));
         filterOptions.useExpandedLayout.optionChooser.setOnCheckedChangeListener((chooser, isChecked) -> sortFilterStatus.setUseTashasExpandedLists(isChecked));
         filterOptions.hideDuplicatesLayout.optionChooser.setOnCheckedChangeListener((chooser, isChecked) -> {
-            sortFilterStatus.setHideDuplicateSpells(isChecked);
-            filterOptions.prefer2024Layout.optionChooser.setEnabled(isChecked);
+            try {
+                sortFilterStatus.setHideDuplicateSpells(isChecked);
+                filterOptions.prefer2024Layout.optionChooser.setEnabled(isChecked);
+            } catch (Exception e) {
+               e.printStackTrace();
+            }
         });
         filterOptions.prefer2024Layout.optionChooser.setOnCheckedChangeListener((chooser, isChecked) -> sortFilterStatus.setPrefer2024Duplicates(isChecked));
 

--- a/app/src/main/java/dnd/jon/spellbook/SpellFilter.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellFilter.java
@@ -211,7 +211,9 @@ class SpellFilter extends Filter {
             // I'd rather avoid a second pass, but since linked spells won't necessarily
             // have the same data, we can't generally know whether we need to filter a spell
             // as a duplicate on the first pass
-            if (hideDuplicates) {
+            final boolean searchTextOnly = isText && !sortFilterStatus.getApplyFiltersToSearch();
+            final boolean doDuplicatesFilter = hideDuplicates && !searchTextOnly;
+            if (doDuplicatesFilter) {
                 final Ruleset rulesetToIgnore = sortFilterStatus.getPrefer2024Duplicates() ? Ruleset.RULES_2014 : Ruleset.RULES_2024;
                 filteredSpellList.removeIf((spell) -> {
                     if (spell.getRuleset() != rulesetToIgnore) {


### PR DESCRIPTION
This PR updates the filtering so that the second duplicate-filtering pass also respect the search text settings, which it currently doesn't do. Additionally, there are a few extra guards in here to try and prevent issues that were showing up in the crash logs.