### PR TITLE
Update navigation calls

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -47,7 +47,6 @@ import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavController;
 import androidx.navigation.NavDestination;
-import androidx.navigation.NavGraph;
 import androidx.navigation.fragment.NavHostFragment;
 
 import org.javatuples.Pair;

--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -47,6 +47,7 @@ import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.NavController;
 import androidx.navigation.NavDestination;
+import androidx.navigation.NavGraph;
 import androidx.navigation.fragment.NavHostFragment;
 
 import org.javatuples.Pair;
@@ -162,26 +163,6 @@ public class MainActivity extends AppCompatActivity
        put(id.nav_favorites, StatusFilterField.FAVORITES);
        put(id.nav_prepared, StatusFilterField.PREPARED);
        put(id.nav_known, StatusFilterField.KNOWN);
-    }};
-
-    private static final Map<Integer,Integer> globalNavigationActions = new HashMap<>() {{
-        put(id.spellSlotManagerFragment, id.action_navigate_to_spell_slots_fragment);
-        put(id.settingsFragment, id.action_navigate_to_settings_fragment);
-        put(id.homebrewManagementFragment, id.action_navigate_to_homebrew_fragment);
-        put(id.spellWindowFragment, id.action_navigate_to_spell_window_fragment);
-        put(id.sortFilterFragment, id.action_navigate_to_sort_filter_fragment);
-    }};
-
-    private static final Map<Pair<Integer,Integer>,Integer> graphNavigationActions = new HashMap<>() {{
-       put(new Pair<>(id.spellTableFragment, id.sortFilterFragment), id.action_spellTableFragment_to_sortFilterFragment);
-       put(new Pair<>(id.sortFilterFragment, id.spellTableFragment), id.action_sortFilterFragment_to_spellTableFragment);
-       put(new Pair<>(id.spellWindowFragment, id.sortFilterFragment), id.action_spellWindowFragment_to_sortFilterFragment);
-       put(new Pair<>(id.sortFilterFragment, id.spellWindowFragment), id.action_sortFilterFragment_to_spellWindowFragment);
-       put(new Pair<>(id.homebrewManagementFragment, id.spellCreationFragment), id.action_homebrewManagementFragment_to_spellCreationFragment);
-       put(new Pair<>(id.homebrewManagementFragment, id.sortFilterFragment), id.action_homebrewManagementFragment_to_sortFilterFragment);
-       put(new Pair<>(id.homebrewManagementFragment, id.spellWindowFragment), id.action_homebrewManagementFragment_to_spellWindowFragment);
-       put(new Pair<>(id.sortFilterFragment, id.homebrewManagementFragment), id.action_sortFilterFragment_to_homebrewManagementFragment);
-       put(new Pair<>(id.spellWindowFragment, id.homebrewManagementFragment), id.action_spellWindowFragment_to_homebrewManagementFragment);
     }};
 
     private static final Map<Integer, Pair<Integer, Integer>> actionBarData = new HashMap<>() {{
@@ -592,10 +573,7 @@ public class MainActivity extends AppCompatActivity
     }
 
     private void globalNavigateTo(int destinationId) {
-        final Integer actionId = globalNavigationActions.get(destinationId);
-        if (actionId != null) {
-            navController.navigate(actionId);
-        }
+        navController.navigate(destinationId);
     }
 
     private void navigateToSpellWindowFragment() {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        def nav_version = "2.6.0"
+        def nav_version = "2.8.1"
         classpath 'com.android.tools.build:gradle:8.7.0'
         classpath "com.likethesalad.android:stem-plugin:2.10.0"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"


### PR DESCRIPTION
The version of the Android navigation library was bumped in #104, so this PR updates a few of the navigation calls to account for that. Additionally, this PR bumps the version of the navigation Gradle plugin.