### PR TITLE
Fix issue with slide-out animation on back press

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -1222,7 +1222,15 @@ public class MainActivity extends AppCompatActivity
 
     @Override
     public boolean dispatchKeyEvent(KeyEvent ev) {
-        if (!onTablet && spellWindowFragment != null && ev.getKeyCode() == KeyEvent.KEYCODE_BACK) {
+        // We only listen for action up events for closing the spell window
+        // If we listen to both up and down, we'll get two separate events
+        // and the close animation doesn't get to finish[
+        if (
+                !onTablet &&
+                spellWindowFragment != null &&
+                ev.getKeyCode() == KeyEvent.KEYCODE_BACK &&
+                ev.getAction() == KeyEvent.ACTION_UP
+        ) {
             closeSpellWindow();
             return true;
         } else {


### PR DESCRIPTION
This PR fixes #109. The issue is that we're currently responding to both action up and down back presses for closing the spell window. Getting two events caused the slide-out animation to get interrupted and not finish correctly. The fix here is to check whether the event is an action up (i.e. when the user has finished pressing the button).