### PR TITLE
Add importing/exporting app content

### DIFF
--- a/app/src/androidTest/java/dnd/jon/spellbook/AndroidTestUtils.java
+++ b/app/src/androidTest/java/dnd/jon/spellbook/AndroidTestUtils.java
@@ -1,0 +1,14 @@
+package dnd.jon.spellbook;
+
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+
+public class AndroidTestUtils {
+
+    static <T> void assertCollectionsSameUnordered(Collection<T> collection1, Collection<T> collection2) {
+        assertEquals(collection1.size(), collection2.size());
+        assertTrue(collection1.containsAll(collection2));
+        assertTrue(collection2.containsAll(collection1));
+    }
+}

--- a/app/src/androidTest/java/dnd/jon/spellbook/InstrumentTest.java
+++ b/app/src/androidTest/java/dnd/jon/spellbook/InstrumentTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -113,7 +114,7 @@ public class InstrumentTest {
 
     @Test
     public void testViewModelLoadContent() {
-        final String jsonString = "{\"profiles\":[{\"CharacterName\":\"Test\",\"SpellFilterStatus\":{\"Spells\":[{\"SpellID\":10,\"Favorite\":true,\"Prepared\":false,\"Known\":false},{\"SpellID\":19,\"Favorite\":true,\"Prepared\":true,\"Known\":true},{\"SpellID\":106,\"Favorite\":true,\"Prepared\":true,\"Known\":true},{\"SpellID\":198,\"Favorite\":false,\"Prepared\":false,\"Known\":true}]},\"SortFilterStatus\":{\"SortField1\":\"Duration\",\"SortField2\":\"Name\",\"Reverse1\":false,\"Reverse2\":true,\"MinSpellLevel\":0,\"MaxSpellLevel\":9,\"ApplyFiltersToSearch\":false,\"ApplyFiltersToSpellLists\":false,\"UseTCEExpandedLists\":false,\"HideDuplicateSpells\":true,\"Prefer2024Spells\":true,\"Ritual\":true,\"NotRitual\":true,\"Concentration\":true,\"NotConcentration\":false,\"ComponentsFilters\":[true,false,true,true],\"NotComponentsFilters\":[true,true,true,true],\"Sourcebooks\":[\"Tasha's Cauldron of Everything\",\"Xanathar's Guide to Everything\",\"Player's Handbook\"],\"Classes\":[\"Artificer\",\"Bard\",\"Cleric\",\"Druid\",\"Paladin\",\"Ranger\",\"Sorcerer\",\"Warlock\",\"Wizard\"],\"Schools\":[\"Abjuration\",\"Conjuration\",\"Divination\",\"Enchantment\",\"Evocation\",\"Illusion\",\"Necromancy\",\"Transmutation\"],\"CastingTimeTypes\":[\"bonus action\",\"reaction\",\"time\"],\"DurationTypes\":[\"Until dispelled\"],\"RangeTypes\":[\"Special\",\"Self\",\"Sight\",\"Finite range\"],\"CastingTimeBounds\":{\"MinValue\":0,\"MaxValue\":24,\"MinUnit\":\"second\",\"MaxUnit\":\"hour\"},\"DurationBounds\":{\"MinValue\":0,\"MaxValue\":30,\"MinUnit\":\"second\",\"MaxUnit\":\"day\"},\"RangeBounds\":{\"MinValue\":0,\"MaxValue\":1,\"MinUnit\":\"foot\",\"MaxUnit\":\"mile\"}},\"SpellSlotStatus\":{\"totalSlots\":[4,3,2,2,1,0,0,0,0],\"usedSlots\":[3,1,0,1,0,0,0,0,0]},\"VersionCode\":\"4.2.0\"}],\"sources\":[{\"name\":\"Test Source\",\"code\":\"TST\",\"spells\":[{\"id\":100000,\"name\":\"Test Spell\",\"desc\":\"abc\",\"higher_level\":\"def\",\"range\":\"3 feet\",\"material\":\"\",\"royalty\":\"\",\"ritual\":false,\"duration\":\"2 seconds\",\"concentration\":true,\"casting_time\":\"1 action\",\"level\":2,\"school\":\"Abjuration\",\"locations\":[{\"sourcebook\":\"TST\",\"page\":-1}],\"components\":[\"V\",\"S\"],\"classes\":[\"Artificer\",\"Paladin\"],\"subclasses\":[],\"tce_expanded_classes\":[],\"ruleset\":\"created\"}]}]}";
+        final String jsonString = "{\"profiles\":[{\"CharacterName\":\"Test\",\"SpellFilterStatus\":{\"Spells\":[{\"SpellID\":10,\"Favorite\":true,\"Prepared\":false,\"Known\":false},{\"SpellID\":19,\"Favorite\":true,\"Prepared\":true,\"Known\":true},{\"SpellID\":106,\"Favorite\":true,\"Prepared\":true,\"Known\":true},{\"SpellID\":198,\"Favorite\":false,\"Prepared\":false,\"Known\":true}]},\"SortFilterStatus\":{\"SortField1\":\"Duration\",\"SortField2\":\"Name\",\"Reverse1\":false,\"Reverse2\":true,\"MinSpellLevel\":0,\"MaxSpellLevel\":9,\"ApplyFiltersToSearch\":false,\"ApplyFiltersToSpellLists\":false,\"UseTCEExpandedLists\":false,\"HideDuplicateSpells\":true,\"Prefer2024Spells\":true,\"Ritual\":true,\"NotRitual\":true,\"Concentration\":true,\"NotConcentration\":false,\"ComponentsFilters\":[true,false,true,true],\"NotComponentsFilters\":[true,true,true,true],\"Sourcebooks\":[\"Tasha's Cauldron of Everything\",\"Xanathar's Guide to Everything\",\"Player's Handbook\"],\"Classes\":[\"Artificer\",\"Bard\",\"Cleric\",\"Druid\",\"Paladin\",\"Ranger\",\"Sorcerer\",\"Warlock\",\"Wizard\"],\"Schools\":[\"Abjuration\",\"Conjuration\",\"Divination\",\"Enchantment\",\"Evocation\",\"Illusion\",\"Necromancy\",\"Transmutation\"],\"CastingTimeTypes\":[\"bonus action\",\"reaction\",\"time\"],\"DurationTypes\":[\"Until dispelled\"],\"RangeTypes\":[\"Special\",\"Self\",\"Sight\",\"Finite range\"],\"CastingTimeBounds\":{\"MinValue\":0,\"MaxValue\":24,\"MinUnit\":\"second\",\"MaxUnit\":\"hour\"},\"DurationBounds\":{\"MinValue\":0,\"MaxValue\":30,\"MinUnit\":\"second\",\"MaxUnit\":\"day\"},\"RangeBounds\":{\"MinValue\":0,\"MaxValue\":1,\"MinUnit\":\"foot\",\"MaxUnit\":\"mile\"}},\"SpellSlotStatus\":{\"totalSlots\":[4,3,2,2,1,0,0,0,0],\"usedSlots\":[3,1,0,1,0,0,0,0,0]},\"VersionCode\":\"4.2.0\"}],\"sources\":[{\"name\":\"Test Source\",\"code\":\"TST\"}],\"spells\":[{\"id\":100000,\"name\":\"Test Spell\",\"desc\":\"abc\",\"higher_level\":\"def\",\"range\":\"3 feet\",\"material\":\"\",\"royalty\":\"\",\"ritual\":false,\"duration\":\"2 seconds\",\"concentration\":true,\"casting_time\":\"1 action\",\"level\":2,\"school\":\"Abjuration\",\"locations\":[{\"sourcebook\":\"TST\",\"page\":-1}],\"components\":[\"V\",\"S\"],\"classes\":[\"Artificer\",\"Paladin\"],\"subclasses\":[],\"tce_expanded_classes\":[],\"ruleset\":\"created\"}]}}";
         try (ActivityScenario<MainActivity>scenario = ActivityScenario.launch(MainActivity.class)) {
             scenario.onActivity(activity -> {
                 try {
@@ -130,6 +131,12 @@ public class InstrumentTest {
                     final List<Spell> createdSpells = viewModel.getCreatedSpells();
                     assertEquals(1, createdSpells.size());
                     final Spell spell = createdSpells.get(0);
+
+                    final Set<Spell> tstSpells = viewModel.getCreatedSpellsForSource(source);
+                    System.out.println(createdSpells);
+                    System.out.println(tstSpells);
+                    AndroidTestUtils.assertCollectionsSameUnordered(createdSpells, tstSpells);
+
                     assertEquals(spell.getName(), "Test Spell");
                     assertEquals(spell.getDescription(), "abc");
                     assertEquals(spell.getHigherLevel(), "def");

--- a/app/src/androidTest/java/dnd/jon/spellbook/InstrumentTest.java
+++ b/app/src/androidTest/java/dnd/jon/spellbook/InstrumentTest.java
@@ -43,7 +43,6 @@ public class InstrumentTest {
     public void useAppContext() {
         // Context of the app under test.
         Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
-
         assertEquals("dnd.jon.spellbook", appContext.getPackageName());
     }
 

--- a/app/src/androidTest/java/dnd/jon/spellbook/InstrumentTest.java
+++ b/app/src/androidTest/java/dnd/jon/spellbook/InstrumentTest.java
@@ -7,6 +7,9 @@ import androidx.test.core.app.ActivityScenario;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,6 +17,9 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -42,62 +48,230 @@ public class InstrumentTest {
 
     @Test
     public void testViewModelLoadSource() {
-        final String json = "{\"name\":\"Test Source\",\"code\":\"TST\",\"spells\":[{\"id\":100000,\"name\":\"Test Spell\",\"desc\":\"abc\",\"higher_level\":\"def\",\"range\":\"3 feet\",\"material\":\"\",\"royalty\":\"\",\"ritual\":false,\"duration\":\"2 seconds\",\"concentration\":true,\"casting_time\":\"1 action\",\"level\":2,\"school\":\"Abjuration\",\"locations\":[{\"sourcebook\":\"TST\",\"page\":-1}],\"components\":[\"V\",\"S\"],\"classes\":[\"Artificer\",\"Paladin\"],\"subclasses\":[],\"tce_expanded_classes\":[],\"ruleset\":\"created\"}]}";
-        try(ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+        final String jsonString = "{\"name\":\"Test Source\",\"code\":\"TST\",\"spells\":[{\"id\":100000,\"name\":\"Test Spell\",\"desc\":\"abc\",\"higher_level\":\"def\",\"range\":\"3 feet\",\"material\":\"\",\"royalty\":\"\",\"ritual\":false,\"duration\":\"2 seconds\",\"concentration\":true,\"casting_time\":\"1 action\",\"level\":2,\"school\":\"Abjuration\",\"locations\":[{\"sourcebook\":\"TST\",\"page\":-1}],\"components\":[\"V\",\"S\"],\"classes\":[\"Artificer\",\"Paladin\"],\"subclasses\":[],\"tce_expanded_classes\":[],\"ruleset\":\"created\"}]}";
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
             scenario.onActivity(activity -> {
-                final SpellbookViewModel viewModel = new ViewModelProvider(activity).get(SpellbookViewModel.class);
-                viewModel.addSourceFromText(json);
+                try {
+                    final SpellbookViewModel viewModel = new ViewModelProvider(activity).get(SpellbookViewModel.class);
+                    final JSONObject json = new JSONObject(jsonString);
+                    viewModel.addSourceFromJSON(json);
 
-                final Source[] createdSources = Source.createdSources();
-                assertEquals(1, createdSources.length);
-                final Source source = createdSources[0];
-                assertEquals(source.getCode(), "TST");
-                assertEquals(source.getDisplayName(), "Test Source");
+                    final Source[] createdSources = Source.createdSources();
+                    assertEquals(1, createdSources.length);
+                    final Source source = createdSources[0];
+                    assertEquals(source.getCode(), "TST");
+                    assertEquals(source.getDisplayName(), "Test Source");
 
-                final List<Spell> createdSpells = viewModel.getCreatedSpells();
-                assertEquals(1, createdSpells.size());
-                final Spell spell = createdSpells.get(0);
-                assertEquals(spell.getName(), "Test Spell");
-                assertEquals(spell.getDescription(), "abc");
-                assertEquals(spell.getHigherLevel(), "def");
-                assertEquals(spell.getID(), 100000);
-                assertTrue(spell.getMaterial().isEmpty());
-                assertTrue(spell.getRoyalty().isEmpty());
-                assertFalse(spell.getRitual());
-                assertTrue(spell.getConcentration());
-                assertEquals(spell.getLevel(), 2);
-                assertEquals(spell.getSchool(), School.ABJURATION);
-                final Map<Source,Integer> locations = spell.getLocations();
-                assertEquals(locations.size(), 1);
-                final Integer page = locations.get(source);
-                assertNotNull(page);
-                assertEquals(page.intValue(), -1);
+                    final List<Spell> createdSpells = viewModel.getCreatedSpells();
+                    assertEquals(1, createdSpells.size());
+                    final Spell spell = createdSpells.get(0);
+                    assertEquals(spell.getName(), "Test Spell");
+                    assertEquals(spell.getDescription(), "abc");
+                    assertEquals(spell.getHigherLevel(), "def");
+                    assertEquals(spell.getID(), 100000);
+                    assertTrue(spell.getMaterial().isEmpty());
+                    assertTrue(spell.getRoyalty().isEmpty());
+                    assertFalse(spell.getRitual());
+                    assertTrue(spell.getConcentration());
+                    assertEquals(spell.getLevel(), 2);
+                    assertEquals(spell.getSchool(), School.ABJURATION);
+                    final Map<Source, Integer> locations = spell.getLocations();
+                    assertEquals(locations.size(), 1);
+                    final Integer page = locations.get(source);
+                    assertNotNull(page);
+                    assertEquals(page.intValue(), -1);
 
-                final Range range = spell.getRange();
-                assertEquals(range.type, Range.RangeType.RANGED);
-                assertEquals(range.value, 3, 0);
-                assertEquals(range.unit, LengthUnit.FOOT);
+                    final Range range = spell.getRange();
+                    assertEquals(range.type, Range.RangeType.RANGED);
+                    assertEquals(range.value, 3, 0);
+                    assertEquals(range.unit, LengthUnit.FOOT);
 
-                final CastingTime castingTime = spell.getCastingTime();
-                assertEquals(castingTime.type, CastingTime.CastingTimeType.ACTION);
-                assertEquals(castingTime.value, 1, 0);
-                assertEquals(castingTime.unit, TimeUnit.SECOND);
+                    final CastingTime castingTime = spell.getCastingTime();
+                    assertEquals(castingTime.type, CastingTime.CastingTimeType.ACTION);
+                    assertEquals(castingTime.value, 1, 0);
+                    assertEquals(castingTime.unit, TimeUnit.SECOND);
 
-                final Duration duration = spell.getDuration();
-                assertEquals(duration.type, Duration.DurationType.SPANNING);
-                assertEquals(duration.value, 2, 0);
-                assertEquals(duration.unit, TimeUnit.SECOND);
+                    final Duration duration = spell.getDuration();
+                    assertEquals(duration.type, Duration.DurationType.SPANNING);
+                    assertEquals(duration.value, 2, 0);
+                    assertEquals(duration.unit, TimeUnit.SECOND);
 
-                assertArrayEquals(spell.getComponents(), new boolean[]{true, true, false, false});
-                assertArrayEquals(spell.getClasses().toArray(), new CasterClass[]{CasterClass.ARTIFICER, CasterClass.PALADIN});
-                assertEquals(spell.getSubclasses().size(), 0);
-                assertEquals(spell.getTashasExpandedClasses().size(), 0);
-                assertEquals(spell.getRuleset(), Ruleset.RULES_CREATED);
+                    assertArrayEquals(spell.getComponents(), new boolean[]{true, true, false, false});
+                    assertArrayEquals(spell.getClasses().toArray(), new CasterClass[]{CasterClass.ARTIFICER, CasterClass.PALADIN});
+                    assertEquals(spell.getSubclasses().size(), 0);
+                    assertEquals(spell.getTashasExpandedClasses().size(), 0);
+                    assertEquals(spell.getRuleset(), Ruleset.RULES_CREATED);
 
+                    assertEquals(1, viewModel.getCreatedSpellsForSource(source).size());
+                } catch (JSONException e) {
+                    e.printStackTrace();
+                    Assert.fail();
+                }
+            });
+        }
+    }
 
+    @Test
+    public void testViewModelLoadContent() {
+        final String jsonString = "{\"profiles\":[{\"CharacterName\":\"Test\",\"SpellFilterStatus\":{\"Spells\":[{\"SpellID\":10,\"Favorite\":true,\"Prepared\":false,\"Known\":false},{\"SpellID\":19,\"Favorite\":true,\"Prepared\":true,\"Known\":true},{\"SpellID\":106,\"Favorite\":true,\"Prepared\":true,\"Known\":true},{\"SpellID\":198,\"Favorite\":false,\"Prepared\":false,\"Known\":true}]},\"SortFilterStatus\":{\"SortField1\":\"Duration\",\"SortField2\":\"Name\",\"Reverse1\":false,\"Reverse2\":true,\"MinSpellLevel\":0,\"MaxSpellLevel\":9,\"ApplyFiltersToSearch\":false,\"ApplyFiltersToSpellLists\":false,\"UseTCEExpandedLists\":false,\"HideDuplicateSpells\":true,\"Prefer2024Spells\":true,\"Ritual\":true,\"NotRitual\":true,\"Concentration\":true,\"NotConcentration\":false,\"ComponentsFilters\":[true,false,true,true],\"NotComponentsFilters\":[true,true,true,true],\"Sourcebooks\":[\"Tasha's Cauldron of Everything\",\"Xanathar's Guide to Everything\",\"Player's Handbook\"],\"Classes\":[\"Artificer\",\"Bard\",\"Cleric\",\"Druid\",\"Paladin\",\"Ranger\",\"Sorcerer\",\"Warlock\",\"Wizard\"],\"Schools\":[\"Abjuration\",\"Conjuration\",\"Divination\",\"Enchantment\",\"Evocation\",\"Illusion\",\"Necromancy\",\"Transmutation\"],\"CastingTimeTypes\":[\"bonus action\",\"reaction\",\"time\"],\"DurationTypes\":[\"Until dispelled\"],\"RangeTypes\":[\"Special\",\"Self\",\"Sight\",\"Finite range\"],\"CastingTimeBounds\":{\"MinValue\":0,\"MaxValue\":24,\"MinUnit\":\"second\",\"MaxUnit\":\"hour\"},\"DurationBounds\":{\"MinValue\":0,\"MaxValue\":30,\"MinUnit\":\"second\",\"MaxUnit\":\"day\"},\"RangeBounds\":{\"MinValue\":0,\"MaxValue\":1,\"MinUnit\":\"foot\",\"MaxUnit\":\"mile\"}},\"SpellSlotStatus\":{\"totalSlots\":[4,3,2,2,1,0,0,0,0],\"usedSlots\":[3,1,0,1,0,0,0,0,0]},\"VersionCode\":\"4.2.0\"}],\"sources\":[{\"name\":\"Test Source\",\"code\":\"TST\",\"spells\":[{\"id\":100000,\"name\":\"Test Spell\",\"desc\":\"abc\",\"higher_level\":\"def\",\"range\":\"3 feet\",\"material\":\"\",\"royalty\":\"\",\"ritual\":false,\"duration\":\"2 seconds\",\"concentration\":true,\"casting_time\":\"1 action\",\"level\":2,\"school\":\"Abjuration\",\"locations\":[{\"sourcebook\":\"TST\",\"page\":-1}],\"components\":[\"V\",\"S\"],\"classes\":[\"Artificer\",\"Paladin\"],\"subclasses\":[],\"tce_expanded_classes\":[],\"ruleset\":\"created\"}]}]}";
+        try (ActivityScenario<MainActivity>scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                try {
+                    final SpellbookViewModel viewModel = new ViewModelProvider(activity).get(SpellbookViewModel.class);
+                    final JSONObject json = new JSONObject(jsonString);
+                    viewModel.loadCreatedContent(json);
 
+                    final Source[] createdSources = Source.createdSources();
+                    assertEquals(1, createdSources.length);
+                    final Source source = createdSources[0];
+                    assertEquals(source.getCode(), "TST");
+                    assertEquals(source.getDisplayName(), "Test Source");
 
-                assertEquals(1, viewModel.getCreatedSpellsForSource(source).size());
+                    final List<Spell> createdSpells = viewModel.getCreatedSpells();
+                    assertEquals(1, createdSpells.size());
+                    final Spell spell = createdSpells.get(0);
+                    assertEquals(spell.getName(), "Test Spell");
+                    assertEquals(spell.getDescription(), "abc");
+                    assertEquals(spell.getHigherLevel(), "def");
+                    assertEquals(spell.getID(), 100000);
+                    assertTrue(spell.getMaterial().isEmpty());
+                    assertTrue(spell.getRoyalty().isEmpty());
+                    assertFalse(spell.getRitual());
+                    assertTrue(spell.getConcentration());
+                    assertEquals(spell.getLevel(), 2);
+                    assertEquals(spell.getSchool(), School.ABJURATION);
+                    final Map<Source, Integer> locations = spell.getLocations();
+                    assertEquals(locations.size(), 1);
+                    final Integer page = locations.get(source);
+                    assertNotNull(page);
+                    assertEquals(page.intValue(), -1);
+
+                    final Range range = spell.getRange();
+                    assertEquals(range.type, Range.RangeType.RANGED);
+                    assertEquals(range.value, 3, 0);
+                    assertEquals(range.unit, LengthUnit.FOOT);
+
+                    final CastingTime castingTime = spell.getCastingTime();
+                    assertEquals(castingTime.type, CastingTime.CastingTimeType.ACTION);
+                    assertEquals(castingTime.value, 1, 0);
+                    assertEquals(castingTime.unit, TimeUnit.SECOND);
+
+                    final Duration duration = spell.getDuration();
+                    assertEquals(duration.type, Duration.DurationType.SPANNING);
+                    assertEquals(duration.value, 2, 0);
+                    assertEquals(duration.unit, TimeUnit.SECOND);
+
+                    assertArrayEquals(spell.getComponents(), new boolean[]{true, true, false, false});
+                    assertArrayEquals(spell.getClasses().toArray(), new CasterClass[]{CasterClass.ARTIFICER, CasterClass.PALADIN});
+                    assertEquals(spell.getSubclasses().size(), 0);
+                    assertEquals(spell.getTashasExpandedClasses().size(), 0);
+                    assertEquals(spell.getRuleset(), Ruleset.RULES_CREATED);
+
+                    assertEquals(1, viewModel.getCreatedSpellsForSource(source).size());
+
+                    final List<String> characterNames = viewModel.getCharacterNames();
+                    assertEquals(characterNames.size(), 1);
+
+                    final CharacterProfile profile = viewModel.getProfileByName(characterNames.get(0));
+                    assertEquals(profile.getName(), "Test");
+
+                    final SortFilterStatus sortFilterStatus = profile.getSortFilterStatus();
+                    final SpellFilterStatus spellFilterStatus = profile.getSpellFilterStatus();
+                    final SpellSlotStatus spellSlotStatus = profile.getSpellSlotStatus();
+                    assertEquals(sortFilterStatus.getStatusFilterField(), StatusFilterField.ALL);
+                    assertEquals(sortFilterStatus.getFirstSortField(), SortField.DURATION);
+                    assertEquals(sortFilterStatus.getSecondSortField(), SortField.NAME);
+                    assertFalse(sortFilterStatus.getFirstSortReverse());
+                    assertTrue(sortFilterStatus.getSecondSortReverse());
+                    assertEquals(sortFilterStatus.getMinSpellLevel(), 0);
+                    assertEquals(sortFilterStatus.getMaxSpellLevel(), 9);
+
+                    // 'Source' is a used-created source, so it should be null and removed
+                    final Collection<Source> shouldBeVisibleSources = new ArrayList<>(Arrays.asList(Source.PLAYERS_HANDBOOK, Source.XANATHARS_GTE, Source.TASHAS_COE));
+                    final Collection<Source> shouldBeHiddenSources = SpellbookUtils.complement(shouldBeVisibleSources, Source.values());
+                    final Collection<Source> visibleSources = sortFilterStatus.getVisibleSources(true);
+                    final Collection<Source> hiddenSources = sortFilterStatus.getVisibleSources(false);
+                    AndroidTestUtils.assertCollectionsSameUnordered(shouldBeVisibleSources, visibleSources);
+                    AndroidTestUtils.assertCollectionsSameUnordered(shouldBeHiddenSources, hiddenSources);
+
+                    final Collection<School> shouldBeVisibleSchools = Arrays.asList(School.values());
+                    AndroidTestUtils.assertCollectionsSameUnordered(shouldBeVisibleSchools, sortFilterStatus.getVisibleSchools(true));
+                    assertEquals(sortFilterStatus.getVisibleSchools(false).size(), 0);
+
+                    final Collection<CasterClass> shouldBeVisibleClasses = Arrays.asList(CasterClass.values());
+                    AndroidTestUtils.assertCollectionsSameUnordered(shouldBeVisibleClasses, sortFilterStatus.getVisibleClasses(true));
+                    assertEquals(sortFilterStatus.getVisibleClasses(false).size(), 0);
+
+                    assertEquals(sortFilterStatus.getMinUnit(CastingTime.CastingTimeType.class), TimeUnit.SECOND);
+                    assertEquals(sortFilterStatus.getMinValue(CastingTime.CastingTimeType.class), 0);
+                    assertEquals(sortFilterStatus.getMaxUnit(CastingTime.CastingTimeType.class), TimeUnit.HOUR);
+                    assertEquals(sortFilterStatus.getMaxValue(CastingTime.CastingTimeType.class), 24);
+
+                    assertEquals(sortFilterStatus.getMinUnit(Range.RangeType.class), LengthUnit.FOOT);
+                    assertEquals(sortFilterStatus.getMinValue(Range.RangeType.class), 0);
+                    assertEquals(sortFilterStatus.getMaxUnit(Range.RangeType.class), LengthUnit.MILE);
+                    assertEquals(sortFilterStatus.getMaxValue(Range.RangeType.class), 1);
+
+                    assertEquals(sortFilterStatus.getMinUnit(Duration.DurationType.class), TimeUnit.SECOND);
+                    assertEquals(sortFilterStatus.getMinValue(Duration.DurationType.class), 0);
+                    assertEquals(sortFilterStatus.getMaxUnit(Duration.DurationType.class), TimeUnit.DAY);
+                    assertEquals(sortFilterStatus.getMaxValue(Duration.DurationType.class), 30);
+
+                    assertTrue(sortFilterStatus.getVerbalFilter(true));
+                    assertFalse(sortFilterStatus.getSomaticFilter(true));
+                    assertTrue(sortFilterStatus.getMaterialFilter(true));
+                    assertTrue(sortFilterStatus.getRoyaltyFilter(true));
+                    assertTrue(sortFilterStatus.getVerbalFilter(false));
+                    assertTrue(sortFilterStatus.getSomaticFilter(false));
+                    assertTrue(sortFilterStatus.getMaterialFilter(false));
+                    assertTrue(sortFilterStatus.getRoyaltyFilter(false));
+
+                    final Collection<CastingTime.CastingTimeType> shouldBeVisibleCastingTimeTypes = new ArrayList<>(Arrays.asList(CastingTime.CastingTimeType.BONUS_ACTION, CastingTime.CastingTimeType.REACTION, CastingTime.CastingTimeType.TIME));
+                    AndroidTestUtils.assertCollectionsSameUnordered(sortFilterStatus.getVisibleCastingTimeTypes(true), shouldBeVisibleCastingTimeTypes);
+                    final Collection<CastingTime.CastingTimeType> shouldBeHiddenCastingTimeTypes = new ArrayList<>(Arrays.asList(CastingTime.CastingTimeType.ACTION));
+                    AndroidTestUtils.assertCollectionsSameUnordered(sortFilterStatus.getVisibleCastingTimeTypes(false), shouldBeHiddenCastingTimeTypes);
+                    final Collection<Duration.DurationType> shouldBeVisibleDurationTypes = new ArrayList<>(Arrays.asList(Duration.DurationType.UNTIL_DISPELLED));
+                    AndroidTestUtils.assertCollectionsSameUnordered(sortFilterStatus.getVisibleDurationTypes(true), shouldBeVisibleDurationTypes);
+                    final Collection<Duration.DurationType> shouldBeHiddenDurationTypes = new ArrayList<>(Arrays.asList(Duration.DurationType.SPECIAL, Duration.DurationType.INSTANTANEOUS, Duration.DurationType.SPANNING));
+                    AndroidTestUtils.assertCollectionsSameUnordered(sortFilterStatus.getVisibleDurationTypes(false), shouldBeHiddenDurationTypes);
+                    final Collection<Range.RangeType> shouldBeVisibleRangeTypes = new ArrayList<>(Arrays.asList(Range.RangeType.SPECIAL, Range.RangeType.SELF, Range.RangeType.SIGHT, Range.RangeType.RANGED));
+                    AndroidTestUtils.assertCollectionsSameUnordered(sortFilterStatus.getVisibleRangeTypes(true), shouldBeVisibleRangeTypes);
+                    final Collection<Range.RangeType> shouldBeHiddenRangeTypes = new ArrayList<>(Arrays.asList(Range.RangeType.TOUCH, Range.RangeType.UNLIMITED));
+                    AndroidTestUtils.assertCollectionsSameUnordered(sortFilterStatus.getVisibleRangeTypes(false), shouldBeHiddenRangeTypes);
+
+                    assertFalse(sortFilterStatus.getApplyFiltersToSearch());
+                    assertFalse(sortFilterStatus.getApplyFiltersToLists());
+                    assertFalse(sortFilterStatus.getUseTashasExpandedLists());
+
+                    assertTrue(sortFilterStatus.getConcentrationFilter(true));
+                    assertFalse(sortFilterStatus.getConcentrationFilter(false));
+                    assertTrue(sortFilterStatus.getRitualFilter(false));
+                    assertTrue(sortFilterStatus.getRitualFilter(false));
+
+                    AndroidTestUtils.assertCollectionsSameUnordered(spellFilterStatus.favoriteSpellIDs(), Arrays.asList(10, 19, 106));
+                    AndroidTestUtils.assertCollectionsSameUnordered(spellFilterStatus.preparedSpellIDs(), Arrays.asList(19, 106));
+                    AndroidTestUtils.assertCollectionsSameUnordered(spellFilterStatus.knownSpellIDs(), Arrays.asList(19, 106, 198));
+
+                    assertEquals(spellSlotStatus.getTotalSlots(1), 4);
+                    assertEquals(spellSlotStatus.getTotalSlots(2), 3);
+                    assertEquals(spellSlotStatus.getTotalSlots(3), 2);
+                    assertEquals(spellSlotStatus.getTotalSlots(4), 2);
+                    assertEquals(spellSlotStatus.getTotalSlots(5), 1);
+                    for (int level = 6; level <= Spellbook.MAX_SPELL_LEVEL; level++) {
+                        assertEquals(spellSlotStatus.getTotalSlots(level), 0);
+                    }
+
+                    assertEquals(spellSlotStatus.getUsedSlots(1), 3);
+                    assertEquals(spellSlotStatus.getUsedSlots(2), 1);
+                    assertEquals(spellSlotStatus.getUsedSlots(3), 0);
+                    assertEquals(spellSlotStatus.getUsedSlots(4), 1);
+                    for (int level = 5; level <= Spellbook.MAX_SPELL_LEVEL; level++) {
+                        assertEquals(spellSlotStatus.getUsedSlots(level), 0);
+                    }
+                } catch (JSONException e) {
+                    e.printStackTrace();
+                    Assert.fail();
+                }
             });
         }
     }

--- a/app/src/main/java/dnd/jon/spellbook/ExportAllContentDialog.java
+++ b/app/src/main/java/dnd/jon/spellbook/ExportAllContentDialog.java
@@ -1,0 +1,83 @@
+package dnd.jon.spellbook;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.Toast;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.NonNull;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.lifecycle.ViewModelProvider;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+import dnd.jon.spellbook.databinding.ExportAllContentBinding;
+
+public class ExportAllContentDialog extends DialogFragment {
+
+    private static final String TAG = "EXPORT_ALL_CONTENT_DIALOG";
+    private SpellbookViewModel viewModel;
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        final FragmentActivity activity = requireActivity();
+        viewModel = new ViewModelProvider(activity, activity.getDefaultViewModelProviderFactory())
+                        .get(SpellbookViewModel.class);
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+
+        final ExportAllContentBinding binding = ExportAllContentBinding.inflate(getLayoutInflater());
+        builder.setView(binding.getRoot());
+
+        final ActivityResultLauncher<String> chooser = registerForActivityResult(new ActivityResultContracts.CreateDocument("application/json"), uri -> {
+            if (uri == null || uri.getPath() == null) {
+                Toast.makeText(activity, R.string.error_exporting_app_content, Toast.LENGTH_SHORT).show();
+                return;
+            }
+
+            try {
+                final OutputStream outputStream = activity.getContentResolver().openOutputStream(uri);
+                final JSONObject json = viewModel.allCreatedContent();
+                final String content = json.toString();
+                final byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+                outputStream.write(bytes);
+            } catch (IOException | JSONException e) {
+                final String errorMessage = getString(R.string.error_exporting_app_content);
+                Log.e(TAG, e.getMessage());
+                Toast.makeText(activity, errorMessage, Toast.LENGTH_SHORT).show();
+            }
+        });
+
+        binding.exportContentCancelButton.setOnClickListener((View view) -> this.dismiss());
+        binding.exportContentFileButton.setOnClickListener((View view) -> chooser.launch(getString(R.string.default_export_content_filename)));
+        binding.exportContentClipboardButton.setOnClickListener((View view) -> {
+            String message;
+            try {
+                final JSONObject json = viewModel.allCreatedContent();
+                final String content = json.toString();
+                final String label = getString(R.string.default_export_content_cliplabel);
+                AndroidUtils.copyToClipboard(activity, content, label);
+                message = getString(R.string.app_content_clipboard_success);
+            } catch (JSONException e) {
+                message = getString(R.string.error_exporting_app_content);
+                Log.e(TAG, e.getMessage());
+            }
+            Toast.makeText(activity, message, Toast.LENGTH_SHORT).show();
+        });
+
+        final AlertDialog dialog = builder.create();
+        dialog.setCanceledOnTouchOutside(true);
+        return dialog;
+    }
+}

--- a/app/src/main/java/dnd/jon/spellbook/ImportContentDialog.java
+++ b/app/src/main/java/dnd/jon/spellbook/ImportContentDialog.java
@@ -1,0 +1,110 @@
+package dnd.jon.spellbook;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.Toast;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.NonNull;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.lifecycle.ViewModelProvider;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+
+import dnd.jon.spellbook.databinding.ImportContentBinding;
+
+public class ImportContentDialog extends DialogFragment {
+
+    private static final String TAG = "IMPORT_CONTENT_DIALOG";
+    private ImportContentBinding binding;
+    private FragmentActivity activity;
+    private SpellbookViewModel viewModel;
+    private ActivityResultLauncher<String[]> importContentFileChooser;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        importContentFileChooser = registerForActivityResult(new ActivityResultContracts.OpenDocument(), uri -> {
+            final FragmentActivity activity = requireActivity();
+            boolean complete = false;
+            int messageID;
+            if (uri == null || uri.getPath() == null) {
+                Toast.makeText(activity, getString(R.string.selected_path_null), Toast.LENGTH_SHORT).show();
+                return;
+            }
+
+            try {
+                final InputStream inputStream = activity.getContentResolver().openInputStream(uri);
+                final String text = new BufferedReader(new InputStreamReader(inputStream))
+                        .lines().collect(Collectors.joining());
+                final JSONObject json = new JSONObject(text);
+                final boolean success = viewModel.loadCreatedContent(json);
+                messageID = success ? R.string.content_loaded_successfully : R.string.issues_loading_some_content;
+                complete = success;
+            } catch (FileNotFoundException | JSONException e) {
+                Log.e(TAG, e.getMessage());
+                messageID = R.string.json_import_error;
+            }
+
+            Toast.makeText(activity, messageID, Toast.LENGTH_SHORT).show();
+            if (complete) {
+                this.dismiss();
+            }
+        });
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+
+        activity = requireActivity();
+        viewModel = new ViewModelProvider(activity, activity.getDefaultViewModelProviderFactory())
+                .get(SpellbookViewModel.class);
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+        binding = ImportContentBinding.inflate(getLayoutInflater());
+        builder.setView(binding.getRoot());
+
+        binding.contentImportButton.setOnClickListener(this::importContentFromText);
+        binding.contentImportFileButton.setOnClickListener(this::importContentFromFile);
+        binding.contentImportCancelButton.setOnClickListener((v) -> this.dismiss());
+
+        return builder.create();
+    }
+
+    private void importContentFromText(View view) {
+        final String jsonString = binding.contentImportEditText.getText().toString();
+        int messageID;
+        boolean complete = true;
+        try {
+            final JSONObject json = new JSONObject(jsonString);
+            final boolean success = viewModel.loadCreatedContent(json);
+            messageID = success ? R.string.content_loaded_successfully : R.string.issues_loading_some_content;
+            complete = success;
+        } catch (JSONException e) {
+            Log.e(TAG, e.getMessage());
+            messageID = R.string.json_import_error;
+        }
+
+        Toast.makeText(activity, messageID, Toast.LENGTH_SHORT).show();
+        if (complete) {
+            this.dismiss();
+        }
+    }
+
+    private void importContentFromFile(View view) {
+        importContentFileChooser.launch(new String[]{"application/json"});
+    }
+}

--- a/app/src/main/java/dnd/jon/spellbook/ImportSourceDialog.java
+++ b/app/src/main/java/dnd/jon/spellbook/ImportSourceDialog.java
@@ -11,8 +11,11 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.ViewModelProvider;
 
 import org.javatuples.Pair;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import dnd.jon.spellbook.databinding.ImportSourceBinding;
+
 
 public class ImportSourceDialog extends DialogFragment {
     private ImportSourceBinding binding;
@@ -32,10 +35,19 @@ public class ImportSourceDialog extends DialogFragment {
 
         binding.sourceImportButton.setOnClickListener((v) -> {
             final String jsonString = binding.sourceImportEditText.getText().toString();
-            final Pair<Boolean,String> result = viewModel.addSourceFromText(jsonString);
+            boolean complete = false;
+            String message;
+            try {
+                final JSONObject json = new JSONObject(jsonString);
+                final Pair<Boolean, String> result = viewModel.addSourceFromJSON(json);
+                message = result.getValue1();
+                complete = result.getValue0();
+            } catch (JSONException e) {
+                message = getString(R.string.invalid_json_for, getString(R.string.source));
+            }
 
-            Toast.makeText(activity, result.getValue1(), Toast.LENGTH_SHORT).show();
-            if (result.getValue0()) {
+            Toast.makeText(activity, message, Toast.LENGTH_SHORT).show();
+            if (complete) {
                 this.dismiss();
             }
         });

--- a/app/src/main/java/dnd/jon/spellbook/JSONUtils.java
+++ b/app/src/main/java/dnd/jon/spellbook/JSONUtils.java
@@ -158,7 +158,7 @@ class JSONUtils {
             final SpellBuilder builder = new SpellBuilder(context);
             for (int i = 0; i < jsonSpells.length(); i++) {
                 final JSONObject item = jsonSpells.getJSONObject(i);
-                final Spell spell = codec.parseSpell(item, builder, false);
+                final Spell spell = codec.parseSpell(item, builder, true);
                 if (spell != null) {
                     spells.add(spell);
                 }

--- a/app/src/main/java/dnd/jon/spellbook/LocalizationUtils.java
+++ b/app/src/main/java/dnd/jon/spellbook/LocalizationUtils.java
@@ -82,6 +82,14 @@ public class LocalizationUtils {
         return getLocalizedContext(context, desiredLocale).getResources();
     }
 
+    static @NonNull Locale getInternalLocale() {
+        return Locale.US;
+    }
+
+    static @NonNull Context getInternalContext(Context context) {
+        return getLocalizedContext(context, getInternalLocale());
+    }
+
     static CasterClass[] supportedClasses() { return CasterClass.values(); }
     static Source[] supportedSources() { return Source.values(); }
     static Source[] supportedCoreSourcebooks() { return Source.coreSourcebooks(); }

--- a/app/src/main/java/dnd/jon/spellbook/SettingsFragment.java
+++ b/app/src/main/java/dnd/jon/spellbook/SettingsFragment.java
@@ -27,6 +27,7 @@ import java.util.Locale;
 public class SettingsFragment extends PreferenceFragmentCompat {
 
     private static final String EXPORT_CONTENT_DIALOG_TAG = "EXPORT_CONTENT_DIALOG";
+    private static final String IMPORT_CONTENT_DIALOG_TAG = "IMPORT_CONTENT_DIALOG";
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
@@ -57,12 +58,20 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             }
         }
 
-        // Set up the listener for the "export all" preference
         final Preference exportAllPreference = findPreference(getString(R.string.export_all));
         if (exportAllPreference != null) {
             exportAllPreference.setOnPreferenceClickListener(preference -> {
                 final ExportAllContentDialog dialog = new ExportAllContentDialog();
                 dialog.show(requireActivity().getSupportFragmentManager(), EXPORT_CONTENT_DIALOG_TAG);
+                return false;
+            });
+        }
+
+        final Preference importContentPreference = findPreference(getString(R.string.import_content));
+        if (importContentPreference != null) {
+            importContentPreference.setOnPreferenceClickListener(preference -> {
+                final ImportContentDialog dialog = new ImportContentDialog();
+                dialog.show(requireActivity().getSupportFragmentManager(), IMPORT_CONTENT_DIALOG_TAG);
                 return false;
             });
         }

--- a/app/src/main/java/dnd/jon/spellbook/SettingsFragment.java
+++ b/app/src/main/java/dnd/jon/spellbook/SettingsFragment.java
@@ -26,6 +26,8 @@ import java.util.Locale;
 
 public class SettingsFragment extends PreferenceFragmentCompat {
 
+    private static final String EXPORT_CONTENT_DIALOG_TAG = "EXPORT_CONTENT_DIALOG";
+
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         setPreferencesFromResource(R.xml.settings_screen, rootKey);
@@ -53,6 +55,16 @@ public class SettingsFragment extends PreferenceFragmentCompat {
                     preferenceCategory.removePreference(languagePreference);
                 }
             }
+        }
+
+        // Set up the listener for the "export all" preference
+        final Preference exportAllPreference = findPreference(getString(R.string.export_all));
+        if (exportAllPreference != null) {
+            exportAllPreference.setOnPreferenceClickListener(preference -> {
+                final ExportAllContentDialog dialog = new ExportAllContentDialog();
+                dialog.show(requireActivity().getSupportFragmentManager(), EXPORT_CONTENT_DIALOG_TAG);
+                return false;
+            });
         }
     }
 

--- a/app/src/main/java/dnd/jon/spellbook/SourceCreationDialog.java
+++ b/app/src/main/java/dnd/jon/spellbook/SourceCreationDialog.java
@@ -17,6 +17,8 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.ViewModelProvider;
 
 import org.javatuples.Pair;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
@@ -49,17 +51,25 @@ public class SourceCreationDialog extends DialogFragment {
                 return;
             }
 
+            String message;
+            boolean complete = false;
             try {
                 final InputStream inputStream = activity.getContentResolver().openInputStream(uri);
                 final String text = new BufferedReader(new InputStreamReader(inputStream))
                         .lines().collect(Collectors.joining());
-                final Pair<Boolean,String> result = viewModel.addSourceFromText(text);
-                Toast.makeText(activity, result.getValue1(), Toast.LENGTH_SHORT).show();
-                if (result.getValue0()) {
-                    dismiss();
-                }
-            } catch (FileNotFoundException e) {
+                final JSONObject json = new JSONObject(text);
+                final Pair<Boolean,String> result = viewModel.addSourceFromJSON(json);
+                message = result.getValue1();
+                complete = result.getValue0();
+
+            } catch (FileNotFoundException | JSONException e) {
                 Log.e(TAG, e.getMessage());
+                message = getString(R.string.invalid_json_for, getString(R.string.source));
+            }
+
+            Toast.makeText(activity, message, Toast.LENGTH_SHORT).show();
+            if (complete) {
+                dismiss();
             }
         });
     }

--- a/app/src/main/java/dnd/jon/spellbook/SourceManagementDialog.java
+++ b/app/src/main/java/dnd/jon/spellbook/SourceManagementDialog.java
@@ -2,6 +2,7 @@ package dnd.jon.spellbook;
 
 import android.app.AlertDialog;
 import android.app.Dialog;
+import android.content.Context;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -70,7 +71,8 @@ public class SourceManagementDialog extends DialogFragment
                 final OutputStream outputStream = activity.getContentResolver().openOutputStream(uri);
                 final Source source = viewModel.getCreatedSourceByName(exportName);
                 final Collection<Spell> spells = viewModel.getCreatedSpellsForSource(source);
-                final String json = JSONUtils.asJSON(source, activity, spells).toString(4);
+                final Context context = LocalizationUtils.getInternalContext(getContext());
+                final String json = JSONUtils.asJSON(source, context, spells).toString(4);
                 final byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
                 outputStream.write(bytes);
             } catch (IOException | JSONException e) {
@@ -124,7 +126,8 @@ public class SourceManagementDialog extends DialogFragment
         try {
             final Source source = viewModel.getCreatedSourceByName(name);
             final Collection<Spell> spells = viewModel.getCreatedSpellsForSource(source);
-            final String json = JSONUtils.asJSON(source, activity, spells).toString();
+            final Context context = LocalizationUtils.getInternalContext(getContext());
+            final String json = JSONUtils.asJSON(source, context, spells).toString();
             final String jsonString = json.toString();
             final String label = name + " JSON";
             AndroidUtils.copyToClipboard(activity, jsonString, label);

--- a/app/src/main/java/dnd/jon/spellbook/Spell.java
+++ b/app/src/main/java/dnd/jon/spellbook/Spell.java
@@ -8,6 +8,7 @@ import android.os.Parcelable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -250,9 +251,15 @@ public class Spell implements Parcelable {
         );
     }
 
-    public boolean equals(Spell other) {
-        if (other == null) { return false; }
-        return id == other.getID();
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof Spell otherSpell)) { return false; }
+        return id == otherSpell.getID();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
     }
 
 }

--- a/app/src/main/java/dnd/jon/spellbook/SpellCodec.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellCodec.java
@@ -55,12 +55,15 @@ class SpellCodec {
     private final String concentrationPrefix;
     private final String ritualEnding;
     private final Context context;
-    SpellCodec(Context context) {
-        final Locale locale = SpellbookUtils.coalesce(context.getResources().getConfiguration().getLocales().get(0), Locale.US);
+    SpellCodec(Context context, Locale locale) {
         this.context = context;
         final String language = locale.getLanguage();
         this.concentrationPrefix = context.getString(concentrationPrefixMap.getOrDefault(language, R.string.concentration_prefix_en));
         this.ritualEnding = context.getString(ritualEndingMap.getOrDefault(language, R.string.ritual_ending_en));
+    }
+
+    SpellCodec(Context context) {
+        this(context, SpellbookUtils.coalesce(context.getResources().getConfiguration().getLocales().get(0), Locale.US));
     }
 
 

--- a/app/src/main/java/dnd/jon/spellbook/SpellbookViewModel.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellbookViewModel.java
@@ -1095,4 +1095,35 @@ public class SpellbookViewModel extends ViewModel implements Filterable {
         return id;
     }
 
+    // "Created content" is all user-created data, including
+    // Character profiles
+    // Created spells + sources
+    JSONObject allCreatedContent() throws JSONException {
+        final JSONObject json = new JSONObject();
+
+        final JSONArray profilesJSON = new JSONArray();
+        final List<String> names = characterNamesLD.getValue();
+        if (names != null) {
+            for (String name : names) {
+                final CharacterProfile profile = getProfileByName(name);
+                if (profile != null) {
+                    profilesJSON.put(profile.toJSON());
+                }
+            }
+        }
+
+        final JSONArray sourcesJSON = new JSONArray();
+        final List<Source> sources = createdSourcesLD.getValue();
+        final Context context = getContext();
+        if (sources != null) {
+            for (Source source: sources) {
+                final Collection<Spell> spells = getCreatedSpellsForSource(source);
+                final JSONObject sourceJSON = JSONUtils.asJSON(source, context, spells);
+                sourcesJSON.put(sourceJSON);
+            }
+        }
+
+        return json;
+    }
+
 }

--- a/app/src/main/java/dnd/jon/spellbook/SpellbookViewModel.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellbookViewModel.java
@@ -1117,7 +1117,7 @@ public class SpellbookViewModel extends ViewModel implements Filterable {
 
         final JSONArray sourcesJSON = new JSONArray();
         final List<Source> sources = createdSourcesLD.getValue();
-        final Context context = LocalizationUtils.getInternalContext(getContext());
+        final Context context = getContext();
         if (sources != null) {
             for (Source source: sources) {
                 final JSONObject sourceJSON = JSONUtils.asJSON(source, context);
@@ -1142,7 +1142,7 @@ public class SpellbookViewModel extends ViewModel implements Filterable {
 
     boolean loadCreatedContent(JSONObject json) {
         boolean anyFailures = false;
-        final Context context = LocalizationUtils.getInternalContext(getContext());
+        final Context context = getContext();
         final JSONArray sources = json.optJSONArray("sources");
         if (sources != null) {
             for (int i = 0; i < sources.length(); i++) {
@@ -1162,7 +1162,7 @@ public class SpellbookViewModel extends ViewModel implements Filterable {
                 final JSONObject spellJSON = spells.optJSONObject(i);
                 if (spellJSON != null) {
                     try {
-                        final Spell spell = codec.parseSpell(spellJSON, builder, true);
+                        final Spell spell = codec.parseSpell(spellJSON, builder, false);
                         addCreatedSpell(spell);
                     } catch (JSONException e) {
                         Log.e(LOGGING_TAG, e.getMessage());

--- a/app/src/main/res/layout/export_all_content.xml
+++ b/app/src/main/res/layout/export_all_content.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:padding="0dp"
+    >
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/bookbackground_2"
+        android:id="@+id/spell_list_export_background"
+        android:layout_alignTop="@id/export_all_content_ll"
+        android:layout_alignBottom="@id/export_all_content_ll"
+        android:layout_alignStart="@id/export_all_content_ll"
+        android:layout_alignEnd="@id/export_all_content_ll"
+        android:scaleType="fitXY"
+        android:contentDescription="@string/book_background_description"
+        />
+
+    <LinearLayout
+        android:id="@+id/export_all_content_ll"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:padding="5dp">
+
+        <androidx.appcompat.widget.AppCompatTextView
+            style="@style/GeneralTextStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:fontFamily="@font/cloister_black"
+            android:gravity="center_horizontal"
+            android:text="@string/export_all_title"
+            android:textSize="@dimen/export_all_content_title_size" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            >
+
+            <Button
+                android:id="@+id/export_content_cancel_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@android:color/transparent"
+                android:foreground="?android:selectableItemBackground"
+                android:text="@string/cancel" />
+
+            <Button
+                android:id="@+id/export_content_clipboard_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@android:color/transparent"
+                android:foreground="?android:selectableItemBackground"
+                android:text="@string/export_json" />
+
+            <Button
+                android:id="@+id/export_content_file_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@android:color/transparent"
+                android:foreground="?android:selectableItemBackground"
+                android:text="@string/export" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/export_all_content.xml
+++ b/app/src/main/res/layout/export_all_content.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -32,16 +33,46 @@
             style="@style/GeneralTextStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_centerHorizontal="true"
             android:fontFamily="@font/cloister_black"
             android:gravity="center_horizontal"
             android:text="@string/export_all_title"
             android:textSize="@dimen/export_all_content_title_size" />
 
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/export_all_subtitle"
+            />
+
+        <com.google.android.flexbox.FlexboxLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingVertical="15dp"
+            app:flexDirection="row"
+            app:justifyContent="space_around"
+            >
+
+            <Button
+                android:id="@+id/export_content_clipboard_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@android:color/transparent"
+                android:foreground="?android:selectableItemBackground"
+                android:text="@string/copy_json" />
+
+            <Button
+                android:id="@+id/export_content_file_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@android:color/transparent"
+                android:foreground="?android:selectableItemBackground"
+                android:text="@string/export_file" />
+
+        </com.google.android.flexbox.FlexboxLayout>
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="center_horizontal"
             >
 
             <Button
@@ -50,23 +81,9 @@
                 android:layout_height="wrap_content"
                 android:background="@android:color/transparent"
                 android:foreground="?android:selectableItemBackground"
-                android:text="@string/cancel" />
-
-            <Button
-                android:id="@+id/export_content_clipboard_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="@android:color/transparent"
-                android:foreground="?android:selectableItemBackground"
-                android:text="@string/export_json" />
-
-            <Button
-                android:id="@+id/export_content_file_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="@android:color/transparent"
-                android:foreground="?android:selectableItemBackground"
-                android:text="@string/export" />
+                android:text="@string/cancel"
+                android:layout_gravity="end"
+                />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/import_content.xml
+++ b/app/src/main/res/layout/import_content.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:id="@+id/import_content"
+    android:padding="0dp"
+    >
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/bookbackground_2"
+        android:id="@+id/content_import_background"
+        android:layout_alignTop="@id/content_import_internal_rl"
+        android:layout_alignBottom="@id/content_import_internal_rl"
+        android:layout_alignStart="@id/content_import_internal_rl"
+        android:layout_alignEnd="@id/content_import_internal_rl"
+        android:scaleType="fitXY"
+        android:contentDescription="@string/book_background_description"
+        />
+
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/content_import_internal_rl"
+        android:padding="15dp"
+        >
+
+        <androidx.appcompat.widget.AppCompatTextView
+            style="@style/GeneralTextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/content_import_title"
+            android:text="@string/import_content_title"
+            android:fontFamily="@font/cloister_black"
+            android:textSize="35sp"
+            android:layout_centerHorizontal="true"
+            />
+
+
+        <TextView
+            style="@style/GeneralTextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/content_import_message"
+            android:text="@string/import_json_from_file"
+            android:layout_below="@id/content_import_title"
+            android:textSize="20sp"
+            android:layout_centerHorizontal="true"
+            />
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/content_import_file_button"
+            android:text="@string/import_json_file"
+            android:layout_below="@id/content_import_message"
+            android:background="@android:color/transparent"
+            android:layout_centerHorizontal="true"
+            />
+
+
+        <TextView
+            style="@style/GeneralTextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/content_paste_message"
+            android:text="@string/or_from_clipboard"
+            android:layout_below="@id/content_import_file_button"
+            android:textSize="20sp"
+            android:layout_centerHorizontal="true"
+            />
+
+
+        <EditText
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/content_import_edit_text"
+            android:layout_below="@id/content_paste_message"
+            android:inputType="text"
+            android:hint="@string/paste_json_here"
+            android:autofillHints="@string/paste_json_here"
+            android:maxHeight="@dimen/dialog_edittext_max_height"
+            />
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/content_import_cancel_button"
+            android:text="@string/cancel"
+            android:layout_below="@id/content_import_edit_text"
+            android:layout_toStartOf="@id/content_import_button"
+            android:background="@android:color/transparent"
+            android:foreground="?android:selectableItemBackground"
+            />
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/content_import_button"
+            android:text="@string/import_text"
+            android:layout_below="@id/content_import_edit_text"
+            android:layout_alignParentEnd="true"
+            android:background="@android:color/transparent"
+            android:foreground="?android:selectableItemBackground"
+            />
+
+    </RelativeLayout>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/import_source.xml
+++ b/app/src/main/res/layout/import_source.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:id="@+id/source_import"

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -154,6 +154,10 @@
     <string name="import_json_file">Importar arquivo JSON</string>
     <string name="import_json_from_file">Importar JSON do arquivo</string>
     <string name="import_json_text">Importar texto JSON</string>
+    <string name="invalid_json">O JSON enviado é inválido</string>
+    <string name="invalid_json_for">JSON para %1$s é inválido</string>
+    <string name="content_loaded_successfully">Conteúdo carregado com sucesso</string>
+    <string name="issues_loading_some_content">Ocorreram problemas ao carregar parte do conteúdo enviado</string>
 
     <!-- Source import from text window -->
     <string name="import_source_title">Fonte de Importação</string>
@@ -298,6 +302,8 @@
     <string name="error_exporting_app_content">Erro ao exportar o conteúdo do aplicativo como JSON</string>
     <string name="default_export_content_filename">ConteúdoFeitiços.json</string>
     <string name="default_export_content_cliplabel">ConteúdoFeitiçosJSON</string>
+    <string name="export_all_subtitle">A partir daqui você pode exportar todo o conteúdo criado (personagens, feitiços, fontes) para carregar em outro dispositivo.</string>
+    <string name="export_file">Exportar para Arquivo</string>
 
     <!-- For spell tables -->
     <string name="one">1</string>
@@ -574,6 +580,7 @@
     <string name="fab_movable_title">Permitir movimento do botão circular</string>
     <string name="show_spell_list_counts">Mostrar contagens da lista de feitiços</string>
     <string name="export_all_title">Exportar todo o Conteúdo</string>
+    <string name="import_content_title">Importar Conteúdo</string>
 
     <!-- Locations -->
     <string name="spell_lists_location">Localização das listas de feitiços</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -293,6 +293,12 @@
     <string name="export_list_expanded_info_title">Todo o Conteúdo do Feitiço</string>
     <string name="export_list_expanded_info_description">Se selecionado, todas as informações do feitiço (como duração, tempo de lançamento, descrição, etc.) serão incluídas no arquivo exportado. Se não for selecionado, apenas as informações básicas sobre feitiços (o que é mostrado na tabela de feitiços do aplicativo) serão incluídas na saída.</string>
 
+    <!-- Exporting all content -->
+    <string name="app_content_clipboard_success">Conteúdo do aplicativo copiado para a área de transferência</string>
+    <string name="error_exporting_app_content">Erro ao exportar o conteúdo do aplicativo como JSON</string>
+    <string name="default_export_content_filename">ConteúdoFeitiços.json</string>
+    <string name="default_export_content_cliplabel">ConteúdoFeitiçosJSON</string>
+
     <!-- For spell tables -->
     <string name="one">1</string>
     <string name="two">2</string>
@@ -567,6 +573,7 @@
     <string name="spell_text_color">Soletrar cor do texto</string>
     <string name="fab_movable_title">Permitir movimento do botão circular</string>
     <string name="show_spell_list_counts">Mostrar contagens da lista de feitiços</string>
+    <string name="export_all_title">Exportar todo o Conteúdo</string>
 
     <!-- Locations -->
     <string name="spell_lists_location">Localização das listas de feitiços</string>

--- a/app/src/main/res/values/global_sizes.xml
+++ b/app/src/main/res/values/global_sizes.xml
@@ -49,5 +49,8 @@
     <dimen name="select_all_text_size">14sp</dimen>
     <dimen name="restore_defaults_text_size">14sp</dimen>
 
+    <!-- Export all content dialog -->
+    <dimen name="export_all_content_title_size">35sp</dimen>
+
 
 </resources>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -5,4 +5,5 @@
     <string name="text_font_size" translatable="false">text_font_size</string>
     <string name="text_color" translatable="false">text_color</string>
     <string name="show_list_counts" translatable="false">show_list_counts</string>
+    <string name="export_all" translatable="false">export_all</string>
 </resources>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -6,4 +6,5 @@
     <string name="text_color" translatable="false">text_color</string>
     <string name="show_list_counts" translatable="false">show_list_counts</string>
     <string name="export_all" translatable="false">export_all</string>
+    <string name="import_content" translatable="false">import_all</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,6 +155,10 @@
     <string name="import_json_file">Import JSON file</string>
     <string name="import_json_from_file">Import JSON from file</string>
     <string name="import_json_text">Import JSON text</string>
+    <string name="invalid_json">Submitted JSON is invalid</string>
+    <string name="invalid_json_for">JSON for %1$s is invalid</string>
+    <string name="content_loaded_successfully">Successfully loaded content</string>
+    <string name="issues_loading_some_content">There were issues loading some of the content</string>
 
     <!-- Source import from text window -->
     <string name="import_source_title">Import Source</string>
@@ -299,6 +303,8 @@
     <string name="error_exporting_app_content">Error exporting app content as JSON</string>
     <string name="default_export_content_filename">SpellbookContent.json</string>
     <string name="default_export_content_cliplabel">SpellbookContentJSON</string>
+    <string name="export_all_subtitle">From here you can export all of your created content (characters, spells, sources) to load into another device.</string>
+    <string name="export_file">Export to File</string>
 
     <!-- For spell tables -->
     <string name="one">1</string>
@@ -576,6 +582,7 @@
     <string name="fab_movable_title">Allow moving circular button</string>
     <string name="show_spell_list_counts">Show spell list counts</string>
     <string name="export_all_title">Export All Content</string>
+    <string name="import_content_title">Import Content</string>
 
     <!-- Locations -->
     <string name="spell_lists_location">Spell lists location</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -294,6 +294,12 @@
     <string name="export_list_expanded_info_title">All Spell Content</string>
     <string name="export_list_expanded_info_description">If selected, all of the spell information (such as the duration, casting time, description, etc.) will be included in the exported file. If not selected, only the basic spell information (what\'s shown in the app\'s spell table) will be included in the output.</string>
 
+    <!-- Exporting all content -->
+    <string name="app_content_clipboard_success">App content copied to clipboard</string>
+    <string name="error_exporting_app_content">Error exporting app content as JSON</string>
+    <string name="default_export_content_filename">SpellbookContent.json</string>
+    <string name="default_export_content_cliplabel">SpellbookContentJSON</string>
+
     <!-- For spell tables -->
     <string name="one">1</string>
     <string name="two">2</string>
@@ -569,6 +575,7 @@
     <string name="spell_text_color">Spell text color</string>
     <string name="fab_movable_title">Allow moving circular button</string>
     <string name="show_spell_list_counts">Show spell list counts</string>
+    <string name="export_all_title">Export All Content</string>
 
     <!-- Locations -->
     <string name="spell_lists_location">Spell lists location</string>

--- a/app/src/main/res/xml-sw600dp/settings_screen.xml
+++ b/app/src/main/res/xml-sw600dp/settings_screen.xml
@@ -65,11 +65,6 @@
 
         <Preference
             android:key="@string/import_content"
-            android:title="@string/export_all_title"
-            />
-
-        <Preference
-            android:key="@string/import_content"
             android:title="@string/import_content_title"
             />
 

--- a/app/src/main/res/xml-sw600dp/settings_screen.xml
+++ b/app/src/main/res/xml-sw600dp/settings_screen.xml
@@ -63,6 +63,16 @@
             android:title="@string/export_all_title"
             />
 
+        <Preference
+            android:key="@string/import_content"
+            android:title="@string/export_all_title"
+            />
+
+        <Preference
+            android:key="@string/import_content"
+            android:title="@string/import_content_title"
+            />
+
     </androidx.preference.PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>

--- a/app/src/main/res/xml-sw600dp/settings_screen.xml
+++ b/app/src/main/res/xml-sw600dp/settings_screen.xml
@@ -58,6 +58,11 @@
             android:defaultValue="true"
             />
 
+        <Preference
+            android:key="@string/export_all"
+            android:title="@string/export_all_title"
+            />
+
     </androidx.preference.PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>

--- a/app/src/main/res/xml/settings_screen.xml
+++ b/app/src/main/res/xml/settings_screen.xml
@@ -76,6 +76,11 @@
             android:defaultValue="true"
             />
 
+        <Preference
+            android:key="@string/export_all"
+            android:title="@string/export_all_title"
+            />
+
     </androidx.preference.PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>

--- a/app/src/main/res/xml/settings_screen.xml
+++ b/app/src/main/res/xml/settings_screen.xml
@@ -81,6 +81,11 @@
             android:title="@string/export_all_title"
             />
 
+        <Preference
+            android:key="@string/import_content"
+            android:title="@string/import_content_title"
+            />
+
     </androidx.preference.PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
This PR implements a user request to allow importing/exporting all created content from the app (character profiles, sources, and spells). This is done in JSON format, either via copy/pasting or by saving/loading using local file storage. This PR also adds a test for checking this behavior.