### PR TITLE
Fix issue where ritual/concentration string was not added to cantrips

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/BindingAdapterUtils.java
+++ b/app/src/main/java/dnd/jon/spellbook/BindingAdapterUtils.java
@@ -17,20 +17,22 @@ public class BindingAdapterUtils {
         tv.setText(ssb);
     }
 
-    @BindingAdapter({"context", "level", "schoolName", "ritual"})
-    public static void schoolLevelText(TextView tv, Context context, int level, String schoolName, boolean ritual) {
-
-        // Handle cantrips
+    public static String schoolLevelText(Context context, int level, String schoolName) {
+        String text;
         if (level == 0) {
-            String text = context.getString(R.string.school_cantrip, schoolName);
+            text = context.getString(R.string.school_cantrip, schoolName);
             text = text.substring(0, 1).toUpperCase() + text.substring(1).toLowerCase();
-            tv.setText(text);
-            return;
+        } else {
+            final String ordinal = level + DisplayUtils.ordinalString(context, level);
+            text = context.getString(R.string.ordinal_school, ordinal, schoolName.toLowerCase());
         }
+        return text;
+    }
 
-        // Handle higher-level spells
-        String ordinal = level + DisplayUtils.ordinalString(context, level);
-        String text = context.getString(R.string.ordinal_school, ordinal, schoolName.toLowerCase());
+    @BindingAdapter({"context", "level", "schoolName", "ritual"})
+    public static void schoolLevelRitualText(TextView tv, Context context, int level, String schoolName, boolean ritual) {
+
+        String text = schoolLevelText(context, level, schoolName);
         if (ritual) {
             final String ritualString = context.getString(R.string.ritual).toLowerCase();
             text += String.format(" (%s)", ritualString);
@@ -39,31 +41,21 @@ public class BindingAdapterUtils {
     }
 
     @BindingAdapter({"context", "level", "schoolName", "ritual", "concentration"})
-    public static void schoolLevelConcentrationText(TextView tv, Context context, int level, String schoolName, boolean ritual, boolean concentration) {
+    public static void schoolLevelRitualConcentrationText(TextView tv, Context context, int level, String schoolName, boolean ritual, boolean concentration) {
 
-        // Handle cantrips
-        if (level == 0) {
-            String text = context.getString(R.string.school_cantrip, schoolName);
-            text = text.substring(0, 1).toUpperCase() + text.substring(1).toLowerCase();
-            tv.setText(text);
-            return;
-        }
-
-        // Handle higher-level spells
-        String ordinal = level + DisplayUtils.ordinalString(context, level);
-        String text = context.getString(R.string.ordinal_school, ordinal, schoolName.toLowerCase());
+        String text = schoolLevelText(context, level, schoolName);
 
         if (ritual || concentration) {
             final StringBuilder builder = new StringBuilder(text);
             builder.append(" (");
             if (ritual) {
-                builder.append("ritual");
+                builder.append(context.getString(R.string.ritual));
             }
             if (ritual && concentration) {
                 builder.append(", ");
             }
             if (concentration) {
-                builder.append("conc.");
+                builder.append(context.getString(R.string.concentration_abbr));
             }
             builder.append(")");
             text = builder.toString();

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -43,6 +43,7 @@
     <string name="locations">Localizações</string>
     <string name="ritual">Ritual</string>
     <string name="concentration">Concentração</string>
+    <string name="concentration_abbr">conc.</string>
     <string name="duration">Duração</string>
     <string name="casting_time">Tempo de Conjuração</string>
     <string name="components">Componentes</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="locations">Locations</string>
     <string name="ritual">Ritual</string>
     <string name="concentration">Concentration</string>
+    <string name="concentration_abbr">conc.</string>
     <string name="duration">Duration</string>
     <string name="casting_time">Casting Time</string>
     <string name="components">Components</string>


### PR DESCRIPTION
This PR resolves #115 by updating the binding adapter that's used in the spell table row. This also does a bit of refactoring and makes sure that we use string resources for ritual/concentration. This doesn't really matter right now since there's not really a difference between English and Portuguese, but it might for a future translation.