### PR TITLE
Fix erroneous concentration tag on 2024 Prestidigitation

### DIFF
--- a/app/src/main/assets/Spells_en.json
+++ b/app/src/main/assets/Spells_en.json
@@ -23893,6 +23893,7 @@
             "V",
             "S"
         ],
+        "concentration": false,
         "desc": "You create a magical effect within range. Choose the effect from the options below. If you cast this spell multiple times, you can have up to three of its non-instantaneous effects active at a time.\n\nSensory Effect. You create an instantaneous, harmless sensory effect, such as a shower of sparks, a puff of wind, faint musical notes, or an odd odor.\n\nFire Play. You instantaneously light or snuff out a candle, a torch, or a small campfire.\n\nClean or Soil. You instantaneously clean or soil an object no larger than 1 cubic foot.\n\nMinor Sensation. You chill, warm, or flavor up to 1 cubic foot of nonliving material for 1 hour.\n\nMagic Mark. You make a color, a small mark, or a symbol appear on an object or a surface for 1 hour.\n\nMinor Creation. You create a nonmagical trinket or an illusory image that can fit in your hand. It lasts until the end of your next turn. A trinket can deal no damage and has no monetary worth.",
         "duration": "Up to 1 hour",
         "id": 801,

--- a/app/src/main/assets/Spells_pt.json
+++ b/app/src/main/assets/Spells_pt.json
@@ -22785,6 +22785,7 @@
             "V",
             "S"
         ],
+        "concentration": false,
         "desc": "Você cria um efeito mágico dentro do alcance. Escolha o efeito nas opções abaixo. Se você conjurar esta magia várias vezes, você pode ter até três de seus efeitos não instantâneos ativos ao mesmo tempo. Efeito Sensorial. Você cria um efeito sensorial instantâneo e inofensivo, como uma chuva de faíscas, uma lufada de vento, notas musicais fracas ou um odor estranho. Jogo de Fogo. Você instantaneamente acende ou apaga uma vela, uma tocha ou uma pequena fogueira. Limpar ou Sujar. Você instantaneamente limpa ou suja um objeto não maior que 1 pé cúbico. Sensação Menor. Você resfria, aquece ou dá sabor a até 1 pé cúbico de material não vivo por 1 hora. Marca Mágica. Você faz uma cor, uma pequena marca ou um símbolo aparecer em um objeto ou superfície por 1 hora. Criação Menor. Você cria uma bugiganga não mágica ou uma imagem ilusória que pode caber em sua mão. Ela dura até o final do seu próximo turno. Uma bugiganga não pode causar dano e não tem valor monetário.",
         "duration": "Até 1 hora",
         "id": 801,


### PR DESCRIPTION
A user pointed out that while Prestidigitation have an "Up to..." duration, it doesn't actually require concentration. This PR fixes this by explicitly setting the concentration for Prestidigitation to false.