### PR TITLE
Specify spinner background in theme

### DIFF
--- a/app/src/main/res/layout/spinner_item.xml
+++ b/app/src/main/res/layout/spinner_item.xml
@@ -11,7 +11,7 @@
     android:layout_centerVertical="true"
     android:textAlignment="center"
     android:textColor="?attr/defaultTextColor"
-    android:background="@android:color/transparent"
+    android:background="?attr/spinnerItemBackground"
     android:singleLine="true"
     android:layout_width="fill_parent"
     android:layout_height="45dp"

--- a/app/src/main/res/layout/spinner_item_smallfont.xml
+++ b/app/src/main/res/layout/spinner_item_smallfont.xml
@@ -5,8 +5,8 @@
     android:textSize="12sp"
     android:singleLine="true"
     android:gravity="center_vertical"
-    android:textColor="#000000"
-    android:background="@android:color/transparent"
+    android:textColor="?attr/defaultTextColor"
+    android:background="?attr/spinnerItemBackground"
     >
 
 </TextView>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,6 +5,7 @@
     <attr name="defaultTextColor" format="reference"/>
     <attr name="bottomNavColor" format="reference"/>
     <attr name="fragmentBackground" format="reference"/>
+    <attr name="spinnerItemBackground" format="reference" />
     <attr name="upArrow" format="reference"/>
     <attr name="downArrow" format="reference"/>
     <attr name="emptyBook" format="reference"/>
@@ -55,6 +56,7 @@
         <item name="emptyWandMipmap">@drawable/wand_empty</item>
         <item name="filledStarBW">@drawable/star_filled_grey</item>
         <item name="menuHeaderColor">@color/menuHeaderColor</item>
+        <item name="spinnerItemBackground">@android:color/transparent</item>
     </style>
 
     <style name="DarkAppTheme" parent="AppTheme">
@@ -71,6 +73,7 @@
         <item name="emptyWand">@drawable/wand_empty_white</item>
         <item name="filledStarBW">@drawable/star_filled_white</item>
         <item name="menuHeaderColor">@color/menuHeaderColorDark</item>
+        <item name="spinnerItemBackground">@color/darkGray</item>
     </style>
 
     <style name="LightAppTheme" parent="AppTheme">
@@ -86,6 +89,7 @@
         <item name="emptyWand">@drawable/wand_empty</item>
         <item name="filledStarBW">@drawable/star_filled_grey</item>
         <item name="menuHeaderColor">@color/menuHeaderColor</item>
+        <item name="spinnerItemBackground">@color/lightBrown</item>
     </style>
 
     <!-- Custom spinner theme


### PR DESCRIPTION
This PR fixes one thing that didn't get set up quite right in #124 - the text in the spinner dropdowns is currently unreadable in dark mode. This updates our themes to specify the spinner item background, so that the text can be readable in each theme.