### PR TITLE
Updates for version 4.4.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "dnd.jon.spellbook"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 4003001
-        versionName "4.3.1"
+        versionCode 4004000
+        versionName "4.4.0"
         signingConfig signingConfigs.release
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/dnd/jon/spellbook/GlobalInfo.java
+++ b/app/src/main/java/dnd/jon/spellbook/GlobalInfo.java
@@ -8,9 +8,9 @@ class GlobalInfo {
     // We don't always want to show an update message
     // i.e. for updates that are pure bugfixes, the old message may be
     // more useful to users
-    static final Version UPDATE_LOG_VERSION = new Version(4,3,1);
+    static final Version UPDATE_LOG_VERSION = new Version(4,4,0);
     static final String UPDATE_LOG_CODE = UPDATE_LOG_VERSION.string();
-    static final int UPDATE_LOG_DESCRIPTION_ID = R.string.update_04_03_01_description;
+    static final int UPDATE_LOG_DESCRIPTION_ID = R.string.update_04_04_00_description;
 
     static final int ANDROID_VERSION = android.os.Build.VERSION.SDK_INT;
 

--- a/app/src/main/java/dnd/jon/spellbook/GlobalInfo.java
+++ b/app/src/main/java/dnd/jon/spellbook/GlobalInfo.java
@@ -2,7 +2,7 @@ package dnd.jon.spellbook;
 
 class GlobalInfo {
 
-    static final Version VERSION = new Version(4,3,1);
+    static final Version VERSION = new Version(4,4,0);
     static final String VERSION_CODE = VERSION.string();
 
     // We don't always want to show an update message

--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -1254,8 +1254,13 @@ public class MainActivity extends SpellbookActivity
 
         // We want to do this no matter what
         if (onTablet && currentDestinationId() == id.spellWindowFragment) {
-            final SpellWindowFragment fragment = (SpellWindowFragment) currentNavigationFragment();
-            fragment.updateSpell(spell);
+            try {
+                final SpellWindowFragment fragment = (SpellWindowFragment) currentNavigationFragment();
+                fragment.updateSpell(spell);
+            } catch (ClassCastException e) {
+                final String message = e.getLocalizedMessage();
+                Log.e(TAG, message != null ? message : "");
+            }
         }
 
         if (ignoreSpellStatusUpdate) {

--- a/app/src/main/res/drawable/fast_scroll_thumb.xml
+++ b/app/src/main/res/drawable/fast_scroll_thumb.xml
@@ -2,7 +2,7 @@
     <item>
         <shape
             android:shape="rectangle">
-            <solid android:color="@color/darkBrown" />
+            <solid android:color="?attr/fastScrollThumbColor" />
             <corners android:radius="32dp" />
         </shape>
     </item>

--- a/app/src/main/res/layout-sw600dp/activity_main.xml
+++ b/app/src/main/res/layout-sw600dp/activity_main.xml
@@ -142,7 +142,7 @@
             android:id="@+id/nav_right_expandable"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:groupIndicator="@drawable/up_down_arrow_icon"
+            android:groupIndicator="?attr/upDownArrow"
             >
         </ExpandableListView>
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -34,11 +34,11 @@
     <string name="nd_level">° nível</string>
     <string name="rd_level">° nível</string>
     <string name="st_level">° nível</string>
-    <string name="school_cantrip">Truque de %s</string>
-    <string name="ordinal_school">%s de %s</string>
+    <string name="school_cantrip">Truque de %1$s</string>
+    <string name="ordinal_school">%1$s de %2$s</string>
 
     <!-- For the spell window -->
-    <string name="prompt">%s: %s</string>
+    <string name="prompt">%1$s: %2$s</string>
     <string name="location">Localização</string>
     <string name="locations">Localizações</string>
     <string name="ritual">Ritual</string>
@@ -533,6 +533,7 @@
     <string name="update_04_02_00_description">O livro de feitiços foi atualizado com as seguintes alterações:\n\n\u2022Agora é possível exportar perfis de personagens e fontes criadas (com feitiços) e importá-los de arquivos JSON.\n\n\u2022Corrigir um bug onde a animação de fechamento da janela de feitiço em um telefone pode ser interrompida incorretamente.</string>
     <string name="update_04_03_00_description">O livro de feitiços foi atualizado com as seguintes alterações:\n\n\u2022Agora é possível importar/exportar <b>todo o conteúdo criado (perfis de personagens, fontes e feitiços)</b> do aplicativo, usando a área de transferência ou arquivos JSON.\n\n\u2022Atualize o texto dos feitiços com <b>erratas do Guia para tudo de Xanathar</b>.\n\n\u2022Corrige um bug onde o status de concentração de cantrips não estava aparecendo no menu de feitiços</string>
     <string name="update_04_03_01_description">Esta atualização corrige a <b>duração do Transmutar Pedra</b>.</string>
+    <string name="update_04_04_00_description">O grimório foi atualizado com as seguintes alterações:\n\n\u2022Agora há a capacidade de <b>alterar o tema visual do grimório</b>. Há três temas - <b>Pergaminho</b> é o visual clássico do grimório, e agora há <b>temas Luz e Escuro</b> também.\n\n\u2022A <b>versão de regras de 2024 Prestidigitação</b> foi marcada anteriormente como exigindo Concentração, o que estava incorreto. Isso foi corrigido.</string>
 
     <!-- Profile/source actions -->
     <string name="rename">Renomear</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,11 +35,11 @@
     <string name="nd_level">nd-level</string>
     <string name="rd_level">rd-level</string>
     <string name="st_level">st-level</string>
-    <string name="school_cantrip">%s cantrip</string>
-    <string name="ordinal_school">%s %s</string>
+    <string name="school_cantrip">%1$s cantrip</string>
+    <string name="ordinal_school">%1$s %2$s</string>
 
     <!-- For the spell window -->
-    <string name="prompt">%s: %s</string>
+    <string name="prompt">%1$s: %2$s</string>
     <string name="location">Location</string>
     <string name="locations">Locations</string>
     <string name="ritual">Ritual</string>
@@ -535,6 +535,7 @@
     <string name="update_04_02_00_description">The spellbook has been updated with the following changes:\n\n\u2022It\'s now possible to export character profiles and created sources (with spells) to, and import them from, JSON files.\n\n\u2022Fix a bug where the closing animation for the spell window on a phone could be incorrectly interrupted.\n\n\u2022Fix issues with the text of Divine Word.</string>
     <string name="update_04_03_00_description">The spellbook has been updated with the following changes:\n\n\u2022It is now possible to import/export <b>all created content (character profiles, sources, and spells)</b> from the app, using either the clipboard or JSON files.\n\n\u2022Update the text of spells with <b>errata from Xanathar\'s Guide to Everything</b>.\n\n\u2022Fix a bug where the concentration status of cantrips was not showing in the spell menu.</string>
     <string name="update_04_03_01_description">This update corrects the <b>duration of Transmute Rock</b>.</string>
+    <string name="update_04_04_00_description">The spellbook has been updated with the following changes:\n\n\u2022There is now the ability to <b>change the spellbook\'s visual theme</b>. There are three themes - <b>Parchment</b> is the classic spellbook look, and there are now <b>Light and Dark themes</b> as well.\n\n\u2022The <b>2024 rules version Prestidigitation</b> was previously marked has requiring Concentration, which was incorrect. This has been fixed.</string>
 
     <!-- Profile/source actions -->
     <string name="rename">Rename</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -17,6 +17,7 @@
     <attr name="filledStarBW" format="reference"/>
     <attr name="menuHeaderColor" format="reference"/>
     <attr name="upDownArrow" format="reference"/>
+    <attr name="fastScrollThumbColor" format="reference"/>
 
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
@@ -57,6 +58,7 @@
         <item name="filledStarBW">@drawable/star_filled_grey</item>
         <item name="menuHeaderColor">@color/menuHeaderColor</item>
         <item name="spinnerItemBackground">@android:color/transparent</item>
+        <item name="fastScrollThumbColor">@color/darkBrown</item>
     </style>
 
     <style name="DarkAppTheme" parent="AppTheme">
@@ -74,6 +76,7 @@
         <item name="filledStarBW">@drawable/star_filled_white</item>
         <item name="menuHeaderColor">@color/menuHeaderColorDark</item>
         <item name="spinnerItemBackground">@color/darkGray</item>
+        <item name="fastScrollThumbColor">@color/lightBrown</item>
     </style>
 
     <style name="LightAppTheme" parent="AppTheme">
@@ -90,6 +93,7 @@
         <item name="filledStarBW">@drawable/star_filled_grey</item>
         <item name="menuHeaderColor">@color/menuHeaderColor</item>
         <item name="spinnerItemBackground">@color/lightBrown</item>
+        <item name="fastScrollThumbColor">@color/darkBrown</item>
     </style>
 
     <!-- Custom spinner theme


### PR DESCRIPTION
This PR bumps the version info and adds an update message for version 4.4.0.

In the process of testing this, I found a couple more bugs to be fixed:
* Use the correct theme-dependent arrow for the expandable list on a tablet
* Fix a bug that could arise when switching spell languages on a tablet
* Update the fast scrolling thumb to be light brown in dark mode due to poor contrast between the background and the thumb