### PR TITLE
Make popup menu styling be theme-dependent

### DIFF
--- a/app/src/main/res/drawable-anydpi/ic_more_vert.xml
+++ b/app/src/main/res/drawable-anydpi/ic_more_vert.xml
@@ -6,6 +6,6 @@
     android:tint="#333333"
     android:alpha="0.6">
   <path
-      android:fillColor="@android:color/white"
+      android:fillColor="?attr/defaultTextColor"
       android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>
 </vector>

--- a/app/src/main/res/drawable-anydpi/ic_more_vert.xml
+++ b/app/src/main/res/drawable-anydpi/ic_more_vert.xml
@@ -3,7 +3,7 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24"
-    android:tint="#333333"
+    android:tint="?attr/defaultTextColor"
     android:alpha="0.6">
   <path
       android:fillColor="?attr/defaultTextColor"

--- a/app/src/main/res/menu/options_menu.xml
+++ b/app/src/main/res/menu/options_menu.xml
@@ -2,7 +2,8 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/background"
+    android:textColor="?attr/defaultTextColor"
+    android:background="?attr/popupItemBackground"
     >
 
     <item

--- a/app/src/main/res/menu/options_menu.xml
+++ b/app/src/main/res/menu/options_menu.xml
@@ -3,7 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:textColor="?attr/defaultTextColor"
-    android:background="?attr/popupItemBackground"
+    android:background="?attr/background"
     >
 
     <item

--- a/app/src/main/res/menu/options_menu.xml
+++ b/app/src/main/res/menu/options_menu.xml
@@ -3,7 +3,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:textColor="?attr/defaultTextColor"
-    android:background="?attr/background"
     >
 
     <item

--- a/app/src/main/res/values-sw600dp/styles.xml
+++ b/app/src/main/res/values-sw600dp/styles.xml
@@ -17,6 +17,7 @@
         <item name="android:subtitleTextColor">?attr/defaultTextColor</item>
         <item name="android:actionMenuTextColor">?attr/defaultTextColor</item>
         <item name="android:navigationBarColor">?attr/defaultTextColor</item>
+        <item name="android:popupMenuStyle">@style/PopupMenu</item>
         <!--        <item name="preferenceTheme">@style/PreferencesTheme</item>-->
         <!--        <item name="preferenceCategoryStyle">@style/PreferencesTheme</item>-->
         <item name="alertDialogTheme">@style/AlertDialogTheme</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -37,6 +37,7 @@
         <item name="android:subtitleTextColor">?attr/defaultTextColor</item>
         <item name="android:actionMenuTextColor">?attr/defaultTextColor</item>
         <item name="android:navigationBarColor">?attr/defaultTextColor</item>
+        <item name="android:popupMenuStyle">@style/PopupMenu</item>
 <!--        <item name="preferenceTheme">@style/PreferencesTheme</item>-->
 <!--        <item name="preferenceCategoryStyle">@style/PreferencesTheme</item>-->
         <item name="alertDialogTheme">@style/AlertDialogTheme</item>
@@ -262,6 +263,10 @@
 <!--        <item name="android:textColorHighlight">?attr/defaultTextColor</item>-->
 <!--        <item name="android:textColorAlertDialogListItem">?attr/defaultTextColor</item>-->
 <!--        <item name="android:editTextColor">?attr/defaultTextColor</item>-->
+    </style>
+
+    <style name="PopupMenu" parent="@android:style/Widget.PopupMenu">
+        <item name="android:popupBackground">?attr/background</item>
     </style>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,7 +6,6 @@
     <attr name="bottomNavColor" format="reference"/>
     <attr name="fragmentBackground" format="reference"/>
     <attr name="spinnerItemBackground" format="reference" />
-    <attr name="popupItemBackground" format="reference" />
     <attr name="upArrow" format="reference"/>
     <attr name="downArrow" format="reference"/>
     <attr name="emptyBook" format="reference"/>
@@ -59,7 +58,6 @@
         <item name="filledStarBW">@drawable/star_filled_grey</item>
         <item name="menuHeaderColor">@color/menuHeaderColor</item>
         <item name="spinnerItemBackground">@android:color/transparent</item>
-        <item name="popupItemBackground">@color/lightBrown</item>
         <item name="fastScrollThumbColor">@color/darkBrown</item>
     </style>
 
@@ -78,7 +76,6 @@
         <item name="filledStarBW">@drawable/star_filled_white</item>
         <item name="menuHeaderColor">@color/menuHeaderColorDark</item>
         <item name="spinnerItemBackground">@color/darkGray</item>
-        <item name="popupItemBackground">@color/darkGray</item>
         <item name="fastScrollThumbColor">@color/lightBrown</item>
     </style>
 
@@ -96,7 +93,6 @@
         <item name="filledStarBW">@drawable/star_filled_grey</item>
         <item name="menuHeaderColor">@color/menuHeaderColor</item>
         <item name="spinnerItemBackground">@color/lightBrown</item>
-        <item name="popupItemBackground">@color/lightBrown</item>
         <item name="fastScrollThumbColor">@color/darkBrown</item>
     </style>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,6 +6,7 @@
     <attr name="bottomNavColor" format="reference"/>
     <attr name="fragmentBackground" format="reference"/>
     <attr name="spinnerItemBackground" format="reference" />
+    <attr name="popupItemBackground" format="reference" />
     <attr name="upArrow" format="reference"/>
     <attr name="downArrow" format="reference"/>
     <attr name="emptyBook" format="reference"/>
@@ -58,6 +59,7 @@
         <item name="filledStarBW">@drawable/star_filled_grey</item>
         <item name="menuHeaderColor">@color/menuHeaderColor</item>
         <item name="spinnerItemBackground">@android:color/transparent</item>
+        <item name="popupItemBackground">@color/lightBrown</item>
         <item name="fastScrollThumbColor">@color/darkBrown</item>
     </style>
 
@@ -76,6 +78,7 @@
         <item name="filledStarBW">@drawable/star_filled_white</item>
         <item name="menuHeaderColor">@color/menuHeaderColorDark</item>
         <item name="spinnerItemBackground">@color/darkGray</item>
+        <item name="popupItemBackground">@color/darkGray</item>
         <item name="fastScrollThumbColor">@color/lightBrown</item>
     </style>
 
@@ -93,6 +96,7 @@
         <item name="filledStarBW">@drawable/star_filled_grey</item>
         <item name="menuHeaderColor">@color/menuHeaderColor</item>
         <item name="spinnerItemBackground">@color/lightBrown</item>
+        <item name="popupItemBackground">@color/lightBrown</item>
         <item name="fastScrollThumbColor">@color/darkBrown</item>
     </style>
 


### PR DESCRIPTION
One thing that was missed in #124 was to create a theme-dependent style for the app's popup menus, which is what this PR does. This is currently particularly problematic in dark mode - the popup menus are using the text coloring and so are unreadable as white text on a white background. With these changes the popup menus have the dark background in dark mode, and so the text is readable.

The styling approach here is similar to that in #125, except that since we're now setting one background for the entire menu (and these items never appear in the primary window, unlike the spinner), we can use the parchment background in the parchment theme.