### PR TITLE
Only check default sources when looking at source IDs

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/DisplayUtils.java
+++ b/app/src/main/java/dnd/jon/spellbook/DisplayUtils.java
@@ -232,7 +232,7 @@ public class DisplayUtils {
 
     static Source sourceFromCode(Context context, String code) {
         try {
-            final Source source = DisplayUtils.getItemFromResourceValue(context, Source.values(), code, Source::getCodeID, Context::getString);
+            final Source source = DisplayUtils.getItemFromResourceValue(context, Source.sourcebooks(), code, Source::getCodeID, Context::getString);
             if (source != null) {
                 return source;
             }


### PR DESCRIPTION
When trying to identify a source by its code's resource ID, we only need to check default sources - created ones don't have an ID.

This isn't just a minor optimization, though - this can actually cause a problem when switching themes if the user has any created sources - this can cause a problem with finding sources for spells, which leads to the spell list being empty. While the effects were pretty noticeable, this was a pretty subtle error that was tricky to track down.