### PR TITLE
Add extra digit to version code

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
         applicationId "dnd.jon.spellbook"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 4004000
+        versionCode 40040000
         versionName "4.4.0"
         signingConfig signingConfigs.release
 


### PR DESCRIPTION
In order to update on the Play Store, we need to add a zero to the version code to account for the sub-patch code that we had for the last release.