### PR TITLE
Make homebrew expandable list color be theme-dependent

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
         applicationId "dnd.jon.spellbook"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 40040000
+        versionCode 40040001
         versionName "4.4.0"
         signingConfig signingConfigs.release
 

--- a/app/src/main/res/layout/homebrew_management.xml
+++ b/app/src/main/res/layout/homebrew_management.xml
@@ -34,6 +34,7 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:id="@+id/created_items_el"
+        android:groupIndicator="?attr/upDownArrow"
         app:layout_constraintTop_toBottomOf="@id/homebrew_help_button"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/homebrew_source_header.xml
+++ b/app/src/main/res/layout/homebrew_source_header.xml
@@ -12,7 +12,7 @@
         android:layout_marginStart="20dp"
         android:padding="10dp"
         android:textStyle="bold"
-        android:textColor="#000000"
+        android:textColor="?attr/defaultTextColor"
         android:textSize="22sp"/>
 
     <!--<ImageButton

--- a/app/src/main/res/layout/homebrew_spell_item.xml
+++ b/app/src/main/res/layout/homebrew_spell_item.xml
@@ -12,7 +12,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="20dp"
         android:padding="10dp"
-        android:textColor="#000000"
+        android:textColor="?attr/defaultTextColor"
         android:textSize="15sp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
This PR fixes another theme item that fell through the cracks - the text color of the homebrew management expandable list.