### PR TITLE
Lowercase ritual in spell table row

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
         applicationId "dnd.jon.spellbook"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 40040001
+        versionCode 40040002
         versionName "4.4.0"
         signingConfig signingConfigs.release
 

--- a/app/src/main/java/dnd/jon/spellbook/BindingAdapterUtils.java
+++ b/app/src/main/java/dnd/jon/spellbook/BindingAdapterUtils.java
@@ -49,7 +49,7 @@ public class BindingAdapterUtils {
             final StringBuilder builder = new StringBuilder(text);
             builder.append(" (");
             if (ritual) {
-                builder.append(context.getString(R.string.ritual));
+                builder.append(context.getString(R.string.ritual).toLowerCase());
             }
             if (ritual && concentration) {
                 builder.append(", ");


### PR DESCRIPTION
This PR fixes a small issue in the UI - in the spell table rows, "Ritual" was being capitalized. While it's not really wrong, it doesn't match with the non-capitalization of the concentration abbreviation, and I like the lowercase better.