### PR TITLE
Prevent homebrew spells from being ignored

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "dnd.jon.spellbook"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 40040002
-        versionName "4.4.0"
+        versionCode 40040010
+        versionName "4.4.1"
         signingConfig signingConfigs.release
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/dnd/jon/spellbook/SpellbookViewModel.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellbookViewModel.java
@@ -213,6 +213,7 @@ public class SpellbookViewModel extends ViewModel implements Filterable {
         final Resources resources = context.getResources();
         final String filename = resources.getString(R.string.spells_filename_language, locale.getLanguage());
         this.spells = loadSpellsFromFile(filename, locale);
+        this.spells.addAll(this.getCreatedSpells());
         this.spellCodec = new SpellCodec(context);
 
         // If we switch locales, we need to update the current spell


### PR DESCRIPTION
This PR fixes a bug that could cause homebrew spells to be ignored when loading spells, making them unaccessible outside of the homebrew management interface.