### PR TITLE
Update default alert dialog styling

### DIFF
--- a/app/src/main/res/values-sw600dp/styles.xml
+++ b/app/src/main/res/values-sw600dp/styles.xml
@@ -21,6 +21,7 @@
         <!--        <item name="preferenceTheme">@style/PreferencesTheme</item>-->
         <!--        <item name="preferenceCategoryStyle">@style/PreferencesTheme</item>-->
         <item name="alertDialogTheme">@style/AlertDialogTheme</item>
+        <item name="android:alertDialogTheme">@style/AlertDialogTheme</item>
         <item name="fragmentBackground">@android:color/transparent</item>
     </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -263,6 +263,7 @@
         <item name="android:background">?attr/alertDialogBackground</item>
         <item name="android:textColor">?attr/defaultTextColor</item>
         <item name="android:textColorAlertDialogListItem">?attr/defaultTextColor</item>
+        <item name="textColorAlertDialogListItem">?attr/defaultTextColor</item>
         <item name="android:titleTextColor">?attr/defaultTextColor</item>
         <item name="android:subtitleTextColor">?attr/defaultTextColor</item>
         <item name="android:textColorPrimary">?attr/defaultTextColor</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,6 +6,7 @@
     <attr name="bottomNavColor" format="reference"/>
     <attr name="fragmentBackground" format="reference"/>
     <attr name="spinnerItemBackground" format="reference" />
+    <attr name="alertDialogBackground" format="reference" />
     <attr name="upArrow" format="reference"/>
     <attr name="downArrow" format="reference"/>
     <attr name="emptyBook" format="reference"/>
@@ -40,7 +41,7 @@
         <item name="android:popupMenuStyle">@style/PopupMenu</item>
 <!--        <item name="preferenceTheme">@style/PreferencesTheme</item>-->
 <!--        <item name="preferenceCategoryStyle">@style/PreferencesTheme</item>-->
-        <item name="alertDialogTheme">@style/AlertDialogTheme</item>
+        <item name="android:alertDialogTheme">@style/AlertDialogTheme</item>
         <item name="fragmentBackground">?attr/background</item>
     </style>
 
@@ -59,6 +60,7 @@
         <item name="filledStarBW">@drawable/star_filled_grey</item>
         <item name="menuHeaderColor">@color/menuHeaderColor</item>
         <item name="spinnerItemBackground">@android:color/transparent</item>
+        <item name="alertDialogBackground">@color/lightBrown</item>
         <item name="fastScrollThumbColor">@color/darkBrown</item>
     </style>
 
@@ -77,6 +79,7 @@
         <item name="filledStarBW">@drawable/star_filled_white</item>
         <item name="menuHeaderColor">@color/menuHeaderColorDark</item>
         <item name="spinnerItemBackground">@color/darkGray</item>
+        <item name="alertDialogBackground">@color/darkGray</item>
         <item name="fastScrollThumbColor">@color/lightBrown</item>
     </style>
 
@@ -94,6 +97,7 @@
         <item name="filledStarBW">@drawable/star_filled_grey</item>
         <item name="menuHeaderColor">@color/menuHeaderColor</item>
         <item name="spinnerItemBackground">@color/lightBrown</item>
+        <item name="alertDialogBackground">@color/lightBrown</item>
         <item name="fastScrollThumbColor">@color/darkBrown</item>
     </style>
 
@@ -251,10 +255,9 @@
 
     <!-- Alert dialogs -->
     <style name="AlertDialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
-<!--        <item name="android:background">?attr/background</item>-->
-<!--        <item name="android:textColor">?attr/defaultTextColor</item>-->
-        <item name="android:background">@android:color/white</item>
-        <item name="android:textColor">@color/black</item>
+        <item name="android:background">?attr/spinnerItemBackground</item>
+        <item name="android:textColor">?attr/defaultTextColor</item>
+        <item name="android:textColorAlertDialogListItem">?attr/defaultTextColor</item>
 <!--        <item name="android:titleTextColor">?attr/defaultTextColor</item>-->
 <!--        <item name="android:subtitleTextColor">?attr/defaultTextColor</item>-->
 <!--        <item name="android:textColorPrimary">?attr/defaultTextColor</item>-->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -259,7 +259,7 @@
 
     <!-- Alert dialogs -->
     <style name="AlertDialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
-        <item name="android:background">?attr/spinnerItemBackground</item>
+        <item name="android:background">?attr/alertDialogBackground</item>
         <item name="android:textColor">?attr/defaultTextColor</item>
         <item name="android:textColorAlertDialogListItem">?attr/defaultTextColor</item>
         <item name="android:titleTextColor">?attr/defaultTextColor</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -42,6 +42,7 @@
         <item name="android:popupMenuStyle">@style/PopupMenu</item>
 <!--        <item name="android:preferenceTheme">@style/PreferencesTheme</item>-->
 <!--        <item name="preferenceCategoryStyle">@style/PreferencesTheme</item>-->
+        <item name="alertDialogTheme">@style/AlertDialogTheme</item>
         <item name="android:alertDialogTheme">@style/AlertDialogTheme</item>
         <item name="fragmentBackground">?attr/background</item>
     </style>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -7,6 +7,7 @@
     <attr name="fragmentBackground" format="reference"/>
     <attr name="spinnerItemBackground" format="reference" />
     <attr name="alertDialogBackground" format="reference" />
+    <attr name="preferenceBackground" format="reference" />
     <attr name="upArrow" format="reference"/>
     <attr name="downArrow" format="reference"/>
     <attr name="emptyBook" format="reference"/>
@@ -39,7 +40,7 @@
         <item name="android:actionMenuTextColor">?attr/defaultTextColor</item>
         <item name="android:navigationBarColor">?attr/defaultTextColor</item>
         <item name="android:popupMenuStyle">@style/PopupMenu</item>
-<!--        <item name="preferenceTheme">@style/PreferencesTheme</item>-->
+<!--        <item name="android:preferenceTheme">@style/PreferencesTheme</item>-->
 <!--        <item name="preferenceCategoryStyle">@style/PreferencesTheme</item>-->
         <item name="android:alertDialogTheme">@style/AlertDialogTheme</item>
         <item name="fragmentBackground">?attr/background</item>
@@ -61,6 +62,7 @@
         <item name="menuHeaderColor">@color/menuHeaderColor</item>
         <item name="spinnerItemBackground">@android:color/transparent</item>
         <item name="alertDialogBackground">@color/lightBrown</item>
+        <item name="preferenceBackground">@color/lightBrown</item>
         <item name="fastScrollThumbColor">@color/darkBrown</item>
     </style>
 
@@ -80,6 +82,7 @@
         <item name="menuHeaderColor">@color/menuHeaderColorDark</item>
         <item name="spinnerItemBackground">@color/darkGray</item>
         <item name="alertDialogBackground">@color/darkGray</item>
+        <item name="preferenceBackground">@color/darkGray</item>
         <item name="fastScrollThumbColor">@color/lightBrown</item>
     </style>
 
@@ -98,6 +101,7 @@
         <item name="menuHeaderColor">@color/menuHeaderColor</item>
         <item name="spinnerItemBackground">@color/lightBrown</item>
         <item name="alertDialogBackground">@color/lightBrown</item>
+        <item name="preferenceBackground">@color/lightBrown</item>
         <item name="fastScrollThumbColor">@color/darkBrown</item>
     </style>
 
@@ -258,14 +262,13 @@
         <item name="android:background">?attr/spinnerItemBackground</item>
         <item name="android:textColor">?attr/defaultTextColor</item>
         <item name="android:textColorAlertDialogListItem">?attr/defaultTextColor</item>
-<!--        <item name="android:titleTextColor">?attr/defaultTextColor</item>-->
-<!--        <item name="android:subtitleTextColor">?attr/defaultTextColor</item>-->
-<!--        <item name="android:textColorPrimary">?attr/defaultTextColor</item>-->
-<!--        <item name="android:textColorSecondary">?attr/defaultTextColor</item>-->
-<!--        <item name="android:textColorTertiary">?attr/defaultTextColor</item>-->
-<!--        <item name="android:textColorHighlight">?attr/defaultTextColor</item>-->
-<!--        <item name="android:textColorAlertDialogListItem">?attr/defaultTextColor</item>-->
-<!--        <item name="android:editTextColor">?attr/defaultTextColor</item>-->
+        <item name="android:titleTextColor">?attr/defaultTextColor</item>
+        <item name="android:subtitleTextColor">?attr/defaultTextColor</item>
+        <item name="android:textColorPrimary">?attr/defaultTextColor</item>
+        <item name="android:textColorSecondary">?attr/defaultTextColor</item>
+        <item name="android:textColorTertiary">?attr/defaultTextColor</item>
+        <item name="android:textColorHighlight">?attr/defaultTextColor</item>
+        <item name="android:editTextColor">?attr/defaultTextColor</item>
     </style>
 
     <style name="PopupMenu" parent="@android:style/Widget.PopupMenu">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -7,6 +7,7 @@
     <attr name="fragmentBackground" format="reference"/>
     <attr name="spinnerItemBackground" format="reference" />
     <attr name="alertDialogBackground" format="reference" />
+    <attr name="alertDialogColorAccent" format="reference" />
     <attr name="preferenceBackground" format="reference" />
     <attr name="upArrow" format="reference"/>
     <attr name="downArrow" format="reference"/>
@@ -63,6 +64,7 @@
         <item name="menuHeaderColor">@color/menuHeaderColor</item>
         <item name="spinnerItemBackground">@android:color/transparent</item>
         <item name="alertDialogBackground">@color/lightBrown</item>
+        <item name="alertDialogColorAccent">@color/darkBrown</item>
         <item name="preferenceBackground">@color/lightBrown</item>
         <item name="fastScrollThumbColor">@color/darkBrown</item>
     </style>
@@ -83,6 +85,7 @@
         <item name="menuHeaderColor">@color/menuHeaderColorDark</item>
         <item name="spinnerItemBackground">@color/darkGray</item>
         <item name="alertDialogBackground">@color/darkGray</item>
+        <item name="alertDialogColorAccent">@color/lightBrown</item>
         <item name="preferenceBackground">@color/darkGray</item>
         <item name="fastScrollThumbColor">@color/lightBrown</item>
     </style>
@@ -102,6 +105,7 @@
         <item name="menuHeaderColor">@color/menuHeaderColor</item>
         <item name="spinnerItemBackground">@color/lightBrown</item>
         <item name="alertDialogBackground">@color/lightBrown</item>
+        <item name="alertDialogColorAccent">@color/darkBrown</item>
         <item name="preferenceBackground">@color/lightBrown</item>
         <item name="fastScrollThumbColor">@color/darkBrown</item>
     </style>
@@ -271,6 +275,8 @@
         <item name="android:textColorTertiary">?attr/defaultTextColor</item>
         <item name="android:textColorHighlight">?attr/defaultTextColor</item>
         <item name="android:editTextColor">?attr/defaultTextColor</item>
+        <item name="android:colorAccent">?attr/alertDialogColorAccent</item>
+        <item name="colorAccent">?attr/alertDialogColorAccent</item>
     </style>
 
     <style name="PopupMenu" parent="@android:style/Widget.PopupMenu">


### PR DESCRIPTION
This PR updates the styling of default alert dialogs to update based on the theme. There are currently only two places where we use dialogs whose layout is constructed via the builder (rather than created from XML, as in every other case):
* The source selection dialog for a homebrew spell
* In the dialogs used by the preference screen

In addition to updating the styling of these dialogs, this also obviously improves any dialogs that we create using the builder UI construction in the future. To do this, we set the alert dialog theme in our app theme. This theme is set up using `attr`s so that it's aware of the overall app theme. Somewhat annoyingly, it seems that the dialogs created by the preferences use non-`android:`-prefixed items, whereas the other dialogs use the `android:` prefix, hence the repeated similar keys throughout the theme.