### PR TITLE
Don't parse profile when exporting JSON; update version info

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "dnd.jon.spellbook"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 40040050
-        versionName "4.4.5"
+        versionCode 40040060
+        versionName "4.4.6"
         signingConfig signingConfigs.release
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/dnd/jon/spellbook/AndroidUtils.java
+++ b/app/src/main/java/dnd/jon/spellbook/AndroidUtils.java
@@ -24,8 +24,20 @@ import androidx.annotation.RequiresApi;
 import org.javatuples.Pair;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 class AndroidUtils {
+
+    static String stringFromInputStream(InputStream inputStream) throws IOException {
+        final int size = inputStream.available();
+        final byte[] buffer = new byte[size];
+        inputStream.read(buffer);
+        inputStream.close();
+        return new String(buffer, StandardCharsets.UTF_8);
+    }
     static Pair<Integer,Integer> screenDimensions(Activity activity) {
         final DisplayMetrics displayMetrics = new DisplayMetrics();
         activity.getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
@@ -68,6 +80,11 @@ class AndroidUtils {
 
     static int resourceIDForAttribute(Context context, int attrID) {
         return resourceIDForAttribute(context.getTheme(), attrID);
+    }
+
+    static String loadStringFromFile(File file) throws IOException {
+        final InputStream inputStream = new FileInputStream(file);
+        return stringFromInputStream(inputStream);
     }
 
 }

--- a/app/src/main/java/dnd/jon/spellbook/CharacterSelectionDialog.java
+++ b/app/src/main/java/dnd/jon/spellbook/CharacterSelectionDialog.java
@@ -20,7 +20,9 @@ import android.view.View;
 import android.widget.Toast;
 
 import org.json.JSONException;
+import org.json.JSONObject;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -81,11 +83,12 @@ public class CharacterSelectionDialog extends DialogFragment
 
             try {
                 final OutputStream outputStream = activity.getContentResolver().openOutputStream(uri);
-                final CharacterProfile profile = viewModel.getProfileByName(exportName);
-                final String json = profile.toJSON().toString(4);
-                final byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+                final File filepath = viewModel.characterFilepath(exportName);
+                final String characterText = AndroidUtils.loadStringFromFile(filepath);
+                final byte[] bytes = characterText.getBytes(StandardCharsets.UTF_8);
                 outputStream.write(bytes);
-            } catch (IOException | JSONException e) {
+            } catch (IOException e) {
+                Toast.makeText(activity, getString(R.string.character_export_error, exportName), Toast.LENGTH_SHORT).show();
                 Log.e(TAG, e.getMessage());
             }
         });

--- a/app/src/main/java/dnd/jon/spellbook/GlobalInfo.java
+++ b/app/src/main/java/dnd/jon/spellbook/GlobalInfo.java
@@ -2,7 +2,7 @@ package dnd.jon.spellbook;
 
 class GlobalInfo {
 
-    static final Version VERSION = new Version(4,4,5);
+    static final Version VERSION = new Version(4,4,6);
     static final String VERSION_CODE = VERSION.string();
 
     // We don't always want to show an update message

--- a/app/src/main/java/dnd/jon/spellbook/JSONUtils.java
+++ b/app/src/main/java/dnd/jon/spellbook/JSONUtils.java
@@ -24,14 +24,6 @@ class JSONUtils {
     static private final String SOURCE_CODE_KEY = "code";
     static private final String SOURCE_SPELLS_KEY = "spells";
 
-    private static String stringFromInputStream(InputStream inputStream) throws IOException {
-        final int size = inputStream.available();
-        final byte[] buffer = new byte[size];
-        inputStream.read(buffer);
-        inputStream.close();
-        return new String(buffer, StandardCharsets.UTF_8);
-    }
-
 //    private static <T> T loadItemFromInputStream(InputStream inputStream, ThrowsExceptionFunction<String,T,IOException> creator) {
 //        try {
 //            final String str = stringFromInputStream(inputStream);
@@ -44,7 +36,7 @@ class JSONUtils {
     private static <T> T loadJSONFromAsset(Context context, String assetFilename, SpellbookUtils.ThrowsExceptionFunction<String,T,JSONException> creator) throws JSONException {
         try {
             final InputStream inputStream = context.getAssets().open(assetFilename);
-            final String str = stringFromInputStream(inputStream);
+            final String str = AndroidUtils.stringFromInputStream(inputStream);
             return creator.apply(str);
         } catch (IOException e) {
             return null;
@@ -62,7 +54,7 @@ class JSONUtils {
     static JSONObject loadJSONFromData(File file) throws JSONException {
         try {
             final InputStream inputStream = new FileInputStream(file);
-            final String str = stringFromInputStream(inputStream);
+            final String str = AndroidUtils.stringFromInputStream(inputStream);
             return new JSONObject(str);
         } catch (IOException e) {
             return null;
@@ -72,7 +64,7 @@ class JSONUtils {
     static String loadAssetAsString(File file) {
         try {
             final InputStream inputStream = new FileInputStream(file);
-            return stringFromInputStream(inputStream);
+            return AndroidUtils.stringFromInputStream(inputStream);
         } catch (IOException e) {
             return null;
         }

--- a/app/src/main/java/dnd/jon/spellbook/SpellbookViewModel.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellbookViewModel.java
@@ -466,9 +466,16 @@ public class SpellbookViewModel extends ViewModel implements Filterable {
 
     private void updateCreatedSpells() { updateCreatedSpells(false); }
 
+    private File dataItemFilepath(String name, String extension, File directory) {
+        return new File(directory, name + extension);
+    }
+
+    File characterFilepath(String name) {
+        return dataItemFilepath(name, CHARACTER_EXTENSION, profilesDir);
+    }
+
     private <T> T getDataItemByName(String name, String extension, File directory, SpellbookUtils.ThrowsExceptionFunction<JSONObject,T,JSONException> creator) {
-        final String filename = name + extension;
-        final File filepath = new File(directory, filename);
+        final File filepath = dataItemFilepath(name, extension, directory);
         if (!(filepath.exists() && filepath.isFile())) {
             return null;
         }

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -462,6 +462,7 @@
     <string name="character_duplicated_toast">Personagem %1$s criado a partir de %2$s</string>
     <string name="status_selected_toast">Configuração selecionada: %1$s</string>
     <string name="character_load_error">Erro ao carregar o perfil do personagem: %1$s</string>
+    <string name="character_export_error">Erro ao exportar JSON de caractere: %1$s</string>
 
     <!-- Filter options -->
     <string name="filter_options_title">Opções de Filtro</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -464,6 +464,7 @@
     <string name="character_duplicated_toast">Character %1$s created from %2$s</string>
     <string name="status_selected_toast">Configuration selected: %1$s</string>
     <string name="character_load_error">Error loading character profile: %1$s</string>
+    <string name="character_export_error">Error exporting character JSON: %1$s</string>
 
     <!-- Filter options -->
     <string name="filter_options_title">Filter Options</string>


### PR DESCRIPTION
This PR updates the logic for the character profile "Export to JSON" functionality to omit the parsing -> serializing step - the currently stored character file is now just exported directly. This means that the file can still be exported even if something happens that messes up the syntax of the profile.

This was pushed out as a quick fix in version 4.4.6, so this PR also updates the version info.