### PR TITLE
Use theme-aware arrow resources after update

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/SortDirectionButton.java
+++ b/app/src/main/java/dnd/jon/spellbook/SortDirectionButton.java
@@ -39,7 +39,7 @@ public class SortDirectionButton extends androidx.appcompat.widget.AppCompatImag
 
     // Update the image to reflect the current direction
     private void updateImage() {
-        int attrID = switch (direction) {
+        final int attrID = switch (direction) {
             case Up -> R.attr.upArrow;
             case Down -> R.attr.downArrow;
         };

--- a/app/src/main/java/dnd/jon/spellbook/SortDirectionButton.java
+++ b/app/src/main/java/dnd/jon/spellbook/SortDirectionButton.java
@@ -39,13 +39,12 @@ public class SortDirectionButton extends androidx.appcompat.widget.AppCompatImag
 
     // Update the image to reflect the current direction
     private void updateImage() {
-        switch (direction) {
-            case Up:
-                setImageResource(R.drawable.up_arrow);
-                break;
-            case Down:
-                setImageResource(R.drawable.down_arrow);
-        }
+        int attrID = switch (direction) {
+            case Up -> R.attr.upArrow;
+            case Down -> R.attr.downArrow;
+        };
+        final int resourceID = AndroidUtils.resourceIDForAttribute(getContext(), attrID);
+        setImageResource(resourceID);
     }
 
     // Toggle the button's direction


### PR DESCRIPTION
Currently the sort direction buttons only initially use the theme-aware arrow resource. After updating, they revert back to the default black arrow image. This is a problem in the dark theme, where those arrows are hard to see. This PR updates the internal method for the arrow image-updating to use the theme-aware `attr`s intead.