### PR TITLE
Use common ID for navigation graph roots

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -165,8 +165,7 @@ public class MainActivity extends SpellbookActivity
     }};
 
     private static final Map<Integer, Pair<Integer, Integer>> actionBarData = new HashMap<>() {{
-       put(id.spellWindowFragment, new Pair<>(string.action_spell_window, drawable.ic_text_snippet));
-       put(id.spellTableFragment, new Pair<>(string.action_table, drawable.ic_list));
+       put(id.rootFragment, new Pair<>(string.action_root, drawable.ic_root));
        put(id.sortFilterFragment, new Pair<>(string.action_filter, drawable.ic_filter));
        put(id.homebrewManagementFragment, new Pair<>(string.homebrew, drawable.cauldron));
     }};
@@ -218,9 +217,9 @@ public class MainActivity extends SpellbookActivity
         }
 
         if (onTablet) {
-            baseFragments = Arrays.asList(id.spellWindowFragment, id.sortFilterFragment, id.homebrewManagementFragment);
+            baseFragments = Arrays.asList(id.rootFragment, id.sortFilterFragment, id.homebrewManagementFragment);
         } else {
-            baseFragments = Arrays.asList(id.spellTableFragment, id.sortFilterFragment);
+            baseFragments = Arrays.asList(id.rootFragment, id.sortFilterFragment);
         }
 
         // Get the spell view model
@@ -310,7 +309,7 @@ public class MainActivity extends SpellbookActivity
 
             @Override
             public void onDrawerOpened(@NonNull View drawerView) {
-                if (currentDestinationId() == id.spellTableFragment) {
+                if (!onTablet && currentDestinationId() == id.rootFragment) {
                     final SpellTableFragment fragment = (SpellTableFragment) currentNavigationFragment();
                     if (fragment != null) {
                         fragment.stopScrolling();
@@ -440,7 +439,7 @@ public class MainActivity extends SpellbookActivity
             @Override
             public boolean onQueryTextChange(String text) {
                 viewModel.setSearchQuery(text);
-                if (currentDestinationId() == id.spellTableFragment) {
+                if (!onTablet && currentDestinationId() == id.rootFragment) {
                     final SpellTableFragment fragment = (SpellTableFragment) currentNavigationFragment();
                     if (fragment != null) {
                         fragment.stopScrolling();
@@ -580,7 +579,7 @@ public class MainActivity extends SpellbookActivity
     }
 
     private void navigateToSpellWindowFragment() {
-        globalNavigateTo(id.spellWindowFragment);
+        globalNavigateTo(id.rootFragment);
     }
 
     private void navigateToSpellTableFragment() {
@@ -593,7 +592,7 @@ public class MainActivity extends SpellbookActivity
     private void navigateToSortFilterFragment() {
         if (onTablet) {
             globalNavigateTo(id.sortFilterFragment);
-        } else if (currentDestinationId() == id.spellTableFragment) {
+        } else if (currentDestinationId() == id.rootFragment) {
             navController.navigate(id.action_spellTableFragment_to_sortFilterFragment);
         }
     }
@@ -602,7 +601,7 @@ public class MainActivity extends SpellbookActivity
         if (onTablet) {
             final NavDestination destination = navController.getCurrentDestination();
             final int destinationID = destination.getId();
-            if (destinationID == id.spellWindowFragment) {
+            if (destinationID == id.rootFragment) {
                 navController.navigate(id.action_spellWindowFragment_to_homebrewManagementFragment);
             } else if (destinationID == id.sortFilterFragment) {
                 navController.navigate(id.action_sortFilterFragment_to_homebrewManagementFragment);
@@ -613,10 +612,12 @@ public class MainActivity extends SpellbookActivity
     }
 
     private void navigateToBaseFragment(int destinationID) {
-        if (destinationID == id.spellWindowFragment) {
-            navigateToSpellWindowFragment();
-        } else if (destinationID == id.spellTableFragment) {
-            navigateToSpellTableFragment();
+        if (destinationID == id.rootFragment) {
+            if (onTablet) {
+                navigateToSpellWindowFragment();
+            } else {
+                navigateToSpellTableFragment();
+            }
         } else if (destinationID == id.sortFilterFragment) {
             navigateToSortFilterFragment();
         } else if (destinationID == id.homebrewManagementFragment) {
@@ -1093,8 +1094,6 @@ public class MainActivity extends SpellbookActivity
 
     // This function takes care of any setup that's needed only on a tablet layout
     private void tabletSetup() {
-        //spellWindowFragment = new SpellWindowFragment();
-        //spellWindowFragment.updateSpell(null);
     }
 
     // If we're on a tablet, this function updates the spell window to match its status in the character profile
@@ -1166,7 +1165,7 @@ public class MainActivity extends SpellbookActivity
         final String sideDrawer = getString(string.side_drawer);
         final String locationOption = prefs.getString(getString(string.spell_slot_locations), fab);
         boolean visible = !locationOption.equals(sideDrawer);
-        visible = visible && (destinationId == id.spellTableFragment);
+        visible = visible && onTablet && (destinationId == id.rootFragment);
         final int visibility = visible ? View.VISIBLE : View.GONE;
         binding.fab.setVisibility(visibility);
         if (visible && openedSpellSlotsFromFAB) {
@@ -1254,7 +1253,7 @@ public class MainActivity extends SpellbookActivity
     private void handleSpellUpdate(Spell spell) {
 
         // We want to do this no matter what
-        if (onTablet && currentDestinationId() == id.spellWindowFragment) {
+        if (onTablet && currentDestinationId() == id.rootFragment) {
             try {
                 final SpellWindowFragment fragment = (SpellWindowFragment) currentNavigationFragment();
                 fragment.updateSpell(spell);
@@ -1270,7 +1269,7 @@ public class MainActivity extends SpellbookActivity
         }
 
         if (onTablet) {
-            globalNavigateTo(id.spellWindowFragment);
+            globalNavigateTo(id.rootFragment);
         } else {
             openSpellWindow(spell);
             final boolean actualSpell = spell != null;
@@ -1389,7 +1388,7 @@ public class MainActivity extends SpellbookActivity
             final int destinationId = destination.getId();
             return baseFragments.contains(destinationId);
         } else {
-            return destination.getId() == id.spellTableFragment;
+            return destination.getId() == id.rootFragment;
         }
     }
 
@@ -1473,7 +1472,7 @@ public class MainActivity extends SpellbookActivity
 
     private void updateActionBar(NavDestination destination) {
         final int destinationId = destination.getId();
-        final boolean searchViewVisible = onTablet || destinationId == id.spellTableFragment;
+        final boolean searchViewVisible = onTablet || destinationId == id.rootFragment;
         final boolean atBaseFragment = baseFragments.contains(destinationId);
         final boolean homebrewIconVisible = atBaseFragment && onTablet;
         final boolean fragmentIcon1Visible = atBaseFragment;
@@ -1524,9 +1523,9 @@ public class MainActivity extends SpellbookActivity
 
         boolean navigationToHome = destinationId == id.sortFilterFragment;
         if (onTablet) {
-            navigationToHome |= (destinationId == id.spellWindowFragment) || (destinationId == id.homebrewManagementFragment);
+            navigationToHome |= (destinationId == id.rootFragment) || (destinationId == id.homebrewManagementFragment);
         } else {
-            navigationToHome |= (destinationId == id.spellTableFragment);
+            navigationToHome |= (destinationId == id.rootFragment);
         }
 
         if (navigationToHome) {

--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -216,6 +216,16 @@ public class MainActivity extends SpellbookActivity
             tabletSetup();
         }
 
+        if (savedInstanceState != null && currentDestinationId() == id.rootFragment) {
+            final Fragment fragment = currentNavigationFragment();
+            if (
+                    (onTablet && (fragment instanceof SpellTableFragment)) || (!onTablet && (fragment instanceof SpellWindowFragment))
+                ) {
+                    navController.popBackStack(id.rootFragment, true);
+                    navController.navigate(id.rootFragment);
+            }
+        }
+
         if (onTablet) {
             baseFragments = Arrays.asList(id.rootFragment, id.sortFilterFragment, id.homebrewManagementFragment);
         } else {
@@ -310,9 +320,14 @@ public class MainActivity extends SpellbookActivity
             @Override
             public void onDrawerOpened(@NonNull View drawerView) {
                 if (!onTablet && currentDestinationId() == id.rootFragment) {
-                    final SpellTableFragment fragment = (SpellTableFragment) currentNavigationFragment();
-                    if (fragment != null) {
-                        fragment.stopScrolling();
+                    try {
+                        final SpellTableFragment fragment = (SpellTableFragment) currentNavigationFragment();
+                        if (fragment != null) {
+                            fragment.stopScrolling();
+                        }
+                    } catch (ClassCastException e) {
+                        final String msg = e.getLocalizedMessage() != null ? e.getLocalizedMessage() : "";
+                        Log.e(TAG, msg);
                     }
                 }
             }
@@ -440,9 +455,14 @@ public class MainActivity extends SpellbookActivity
             public boolean onQueryTextChange(String text) {
                 viewModel.setSearchQuery(text);
                 if (!onTablet && currentDestinationId() == id.rootFragment) {
-                    final SpellTableFragment fragment = (SpellTableFragment) currentNavigationFragment();
-                    if (fragment != null) {
-                        fragment.stopScrolling();
+                    try {
+                        final SpellTableFragment fragment = (SpellTableFragment) currentNavigationFragment();
+                        if (fragment != null) {
+                            fragment.stopScrolling();
+                        }
+                    } catch (ClassCastException e) {
+                        final String msg = e.getLocalizedMessage() != null ? e.getLocalizedMessage() : "";
+                        Log.e(TAG, msg);
                     }
                 }
                 return true;

--- a/app/src/main/res/navigation-sw600dp/nav_graph.xml
+++ b/app/src/main/res/navigation-sw600dp/nav_graph.xml
@@ -4,7 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/spellWindowFragment"
+    app:startDestination="@id/rootFragment"
     >
 
     <action
@@ -25,7 +25,7 @@
         />
 
     <fragment
-        android:id="@+id/spellWindowFragment"
+        android:id="@+id/rootFragment"
         android:name="dnd.jon.spellbook.SpellWindowFragment"
         android:label="SpellWindowFragment" >
         <action
@@ -41,7 +41,7 @@
         android:label="SortFilterFragment" >
         <action
             android:id="@+id/action_sortFilterFragment_to_spellWindowFragment"
-            app:destination="@id/spellWindowFragment" />
+            app:destination="@id/rootFragment" />
         <action
             android:id="@+id/action_sortFilterFragment_to_homebrewManagementFragment"
             app:destination="@id/homebrewManagementFragment" />
@@ -63,7 +63,7 @@
             app:destination="@id/spellCreationFragment" />
         <action
             android:id="@+id/action_homebrewManagementFragment_to_spellWindowFragment"
-            app:destination="@id/spellWindowFragment" />
+            app:destination="@id/rootFragment" />
         <action
             android:id="@+id/action_homebrewManagementFragment_to_sortFilterFragment"
             app:destination="@id/sortFilterFragment" />
@@ -72,5 +72,5 @@
         android:id="@+id/spellCreationFragment"
         android:name="dnd.jon.spellbook.SpellCreationFragment"
         android:label="SpellCreationFragment" />
-    <action android:id="@+id/action_navigate_to_spell_window_fragment" app:destination="@id/spellWindowFragment" />
+    <action android:id="@+id/action_navigate_to_spell_window_fragment" app:destination="@id/rootFragment" />
 </navigation>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -4,7 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/spellTableFragment"
+    app:startDestination="@id/rootFragment"
     >
 
     <action
@@ -29,7 +29,7 @@
         />
 
     <fragment
-        android:id="@+id/spellTableFragment"
+        android:id="@+id/rootFragment"
         android:name="dnd.jon.spellbook.SpellTableFragment"
         android:label="SpellTableFragment" >
         <action
@@ -42,7 +42,7 @@
         android:label="SortFilterFragment" >
         <action
             android:id="@+id/action_sortFilterFragment_to_spellTableFragment"
-            app:destination="@id/spellTableFragment" />
+            app:destination="@id/rootFragment" />
     </fragment>
     <fragment
         android:id="@+id/spellSlotManagerFragment"

--- a/app/src/main/res/values-pt-sw600dp/strings.xml
+++ b/app/src/main/res/values-pt-sw600dp/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="action_root">Janela de feitiço</string>
+</resources>

--- a/app/src/main/res/values-sw600dp/device_attributes.xml
+++ b/app/src/main/res/values-sw600dp/device_attributes.xml
@@ -2,4 +2,5 @@
 <resources>
     <bool name="isTablet">true</bool>
     <bool name="isPhone">false</bool>
+    <item type="drawable" name="ic_root">@drawable/ic_text_snippet</item>
 </resources>

--- a/app/src/main/res/values-sw600dp/strings.xml
+++ b/app/src/main/res/values-sw600dp/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="action_root">Spell window</string>
+</resources>

--- a/app/src/main/res/values/device_attributes.xml
+++ b/app/src/main/res/values/device_attributes.xml
@@ -2,4 +2,5 @@
 <resources>
     <bool name="isTablet">false</bool>
     <bool name="isPhone">true</bool>
+    <item type="drawable" name="ic_root">@drawable/ic_list</item>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,7 @@
     <string name="action_info">Spellcasting info</string>
     <string name="action_search">Search</string>
     <string name="search_hint">Search</string>
+    <string name="action_root">Spell table</string>
     <string name="action_spell_window">Spell window</string>
     <string name="action_table">Spell table</string>
     <string name="action_filter">Filter</string>


### PR DESCRIPTION
This PR fixes #147 by modifying the two navigation graphs so that they use the same ID as the graph root. This necessitated adding a few `onTablet` checks in a few places - previously we used the distinction between the `id.spellTableFragment` and `id.spellWindowFragment` roots. Since the actually root fragment type is different between the phone and tablet, we also need a quick check in `onCreate` to force re-navigate if necessary to make sure that we use the correct fragment type if the nav graph has switched on the re-create.