### PR TITLE
Fix filter option reset bug on recreate

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -1210,7 +1210,7 @@ public class MainActivity extends SpellbookActivity
         final String sideDrawer = getString(string.side_drawer);
         final String locationOption = prefs.getString(getString(string.spell_slot_locations), fab);
         boolean visible = !locationOption.equals(sideDrawer);
-        visible = visible && onTablet && (destinationId == id.rootFragment);
+        visible = visible && !onTablet && (destinationId == id.rootFragment);
         final int visibility = visible ? View.VISIBLE : View.GONE;
         binding.fab.setVisibility(visibility);
         if (visible && openedSpellSlotsFromFAB) {

--- a/app/src/main/java/dnd/jon/spellbook/SortFilterFragment.java
+++ b/app/src/main/java/dnd/jon/spellbook/SortFilterFragment.java
@@ -9,6 +9,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.Button;
+import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.GridLayout;
 import android.widget.Spinner;
@@ -90,6 +91,7 @@ public class SortFilterFragment extends SpellbookFragment<SortFilterLayoutBindin
     @SuppressLint("StaticFieldLeak")
     private static SortFilterLayoutBinding rootBinding = null;
     private static boolean needSetup = true;
+    private static boolean active = false;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
@@ -123,6 +125,18 @@ public class SortFilterFragment extends SpellbookFragment<SortFilterLayoutBindin
         final SortFilterLayoutBinding originalBinding = binding;
         super.onDestroyView();
         binding = originalBinding;
+    }
+
+    @Override
+    public void onStart() {
+        active = true;
+        super.onStart();
+    }
+
+    @Override
+    public void onStop() {
+        active = false;
+        super.onStop();
     }
 
     @Override
@@ -215,22 +229,48 @@ public class SortFilterFragment extends SpellbookFragment<SortFilterLayoutBindin
 //        });
 //    }
 
+    private void filterCheckedChangeListener(CompoundButton chooser, boolean isChecked, BiConsumer<SortFilterStatus,Boolean> sortFilterUpdater) {
+        if (active) {
+            sortFilterUpdater.accept(sortFilterStatus, isChecked);
+        }
+    }
+
+    private void filterListsCheckedChangeListener(CompoundButton chooser, boolean isChecked) {
+        filterCheckedChangeListener(chooser, isChecked, SortFilterStatus::setApplyFiltersToLists);
+    }
+
+    private void filterSearchCheckedChangeListener(CompoundButton chooser, boolean isChecked) {
+        filterCheckedChangeListener(chooser, isChecked, SortFilterStatus::setApplyFiltersToSearch);
+    }
+
+    private void useTashasCheckedChangeListener(CompoundButton chooser, boolean isChecked) {
+        filterCheckedChangeListener(chooser, isChecked, SortFilterStatus::setUseTashasExpandedLists);
+    }
+
+    private void prefer2024CheckedChangeListener(CompoundButton chooser, boolean isChecked) {
+        filterCheckedChangeListener(chooser, isChecked, SortFilterStatus::setPrefer2024Duplicates);
+    }
+
+    private void hideDuplicatesCheckedChangeListener(CompoundButton chooser, boolean isChecked) {
+        try {
+            if (active) {
+                sortFilterStatus.setHideDuplicateSpells(isChecked);
+                binding.filterOptions.prefer2024Layout.optionChooser.setEnabled(isChecked);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
     private void setupFilterOptions() {
 
         // Set up the bindings
         final FilterOptionsLayoutBinding filterOptions = binding.filterOptions;
-        filterOptions.filterListsLayout.optionChooser.setOnCheckedChangeListener((chooser, isChecked) -> sortFilterStatus.setApplyFiltersToLists(isChecked));
-        filterOptions.filterSearchLayout.optionChooser.setOnCheckedChangeListener((chooser, isChecked) -> sortFilterStatus.setApplyFiltersToSearch(isChecked));
-        filterOptions.useExpandedLayout.optionChooser.setOnCheckedChangeListener((chooser, isChecked) -> sortFilterStatus.setUseTashasExpandedLists(isChecked));
-        filterOptions.hideDuplicatesLayout.optionChooser.setOnCheckedChangeListener((chooser, isChecked) -> {
-            try {
-                sortFilterStatus.setHideDuplicateSpells(isChecked);
-                filterOptions.prefer2024Layout.optionChooser.setEnabled(isChecked);
-            } catch (Exception e) {
-               e.printStackTrace();
-            }
-        });
-        filterOptions.prefer2024Layout.optionChooser.setOnCheckedChangeListener((chooser, isChecked) -> sortFilterStatus.setPrefer2024Duplicates(isChecked));
+        filterOptions.filterListsLayout.optionChooser.setOnCheckedChangeListener(this::filterListsCheckedChangeListener);
+        filterOptions.filterSearchLayout.optionChooser.setOnCheckedChangeListener(this::filterSearchCheckedChangeListener);
+        filterOptions.useExpandedLayout.optionChooser.setOnCheckedChangeListener(this::useTashasCheckedChangeListener);
+        filterOptions.hideDuplicatesLayout.optionChooser.setOnCheckedChangeListener(this::hideDuplicatesCheckedChangeListener);
+        filterOptions.prefer2024Layout.optionChooser.setOnCheckedChangeListener(this::prefer2024CheckedChangeListener);
 
         filterOptions.filterListsLayout.optionInfoButton.setOnClickListener((v) -> openOptionInfoDialog(filterOptions.filterListsLayout));
         filterOptions.filterSearchLayout.optionInfoButton.setOnClickListener((v) -> openOptionInfoDialog(filterOptions.filterSearchLayout));

--- a/app/src/main/java/dnd/jon/spellbook/SortFilterFragment.java
+++ b/app/src/main/java/dnd/jon/spellbook/SortFilterFragment.java
@@ -130,6 +130,9 @@ public class SortFilterFragment extends SpellbookFragment<SortFilterLayoutBindin
     @Override
     public void onStart() {
         active = true;
+        if (sortFilterStatus != null) {
+            updateSortFilterStatus(sortFilterStatus);
+        }
         super.onStart();
     }
 

--- a/app/src/main/java/dnd/jon/spellbook/SortFilterStatus.java
+++ b/app/src/main/java/dnd/jon/spellbook/SortFilterStatus.java
@@ -129,6 +129,8 @@ public class SortFilterStatus extends BaseObservable implements Named, Parcelabl
         applyFiltersToLists = in.readByte() != 0;
         applyFiltersToSearch = in.readByte() != 0;
         useTashasExpandedLists = in.readByte() != 0;
+        hideDuplicateSpells = in.readByte() != 0;
+        prefer2024Duplicates = in.readByte() != 0;
         yesRitual = in.readByte() != 0;
         noRitual = in.readByte() != 0;
         yesConcentration = in.readByte() != 0;
@@ -784,6 +786,8 @@ public class SortFilterStatus extends BaseObservable implements Named, Parcelabl
         parcel.writeByte((byte) (applyFiltersToLists ? 1 : 0));
         parcel.writeByte((byte) (applyFiltersToSearch ? 1 : 0));
         parcel.writeByte((byte) (useTashasExpandedLists ? 1 : 0));
+        parcel.writeByte((byte) (hideDuplicateSpells ? 1 : 0));
+        parcel.writeByte((byte) (prefer2024Duplicates ? 1 : 0));
         parcel.writeByte((byte) (yesRitual ? 1 : 0));
         parcel.writeByte((byte) (noRitual ? 1 : 0));
         parcel.writeByte((byte) (yesConcentration ? 1 : 0));


### PR DESCRIPTION
This PR fixes #151. It seems that the issue is that the filter option switches haven't had time to update from their default value of being checked before the checked change listeners fire when one leaves the settings fragment (maybe they don't update until the view is visible?). The solution here is to track whether or not the sort/filter fragment is active, and to pass on updating the `SortFilterStatus` if it's not.

We need to make `active` a static variable here - we already do some abuse of the lifecycle system in order to keep the guts of the sort/filter fragment from being recreated, and so relying on just an instance member causes issues.

EDIT: Along the way, this also fixes a bug in the FAB visibility logic introduced in #148.