### PR TITLE
Fix spinner background in parchment theme

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/DefaultSpinnerAdapter.java
+++ b/app/src/main/java/dnd/jon/spellbook/DefaultSpinnerAdapter.java
@@ -49,7 +49,7 @@ class DefaultSpinnerAdapter<T> extends ArrayAdapter<T> {
 
     @Override
     public View getDropDownView(int position, View convertView, @NonNull ViewGroup parent) {
-        return getSpinnerRow(position, parent);
+        return getSpinnerRow(position, parent, true);
     }
 
     void setEnabledItemFilter(Function<Integer,Boolean> filter) {
@@ -68,11 +68,11 @@ class DefaultSpinnerAdapter<T> extends ArrayAdapter<T> {
     @NonNull
     public View getView(int position, View convertView, @NonNull ViewGroup parent) {
         notifyDataSetChanged();
-        return getSpinnerRow(position, parent);
+        return getSpinnerRow(position, parent, false);
     }
 
-    private View getSpinnerRow(int position, ViewGroup parent) {
-        LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+    private View getSpinnerRow(int position, ViewGroup parent, boolean dropdown) {
+        final LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         final View row = inflater.inflate(layoutID, parent, false);
         final TextView label = row.findViewById(labelID);
         label.setText(textFunction.apply(context, getItem(position)));
@@ -82,6 +82,8 @@ class DefaultSpinnerAdapter<T> extends ArrayAdapter<T> {
             final int color = context.getColor(colorID);
             label.setTextColor(color);
         }
+        final int backgroundID = dropdown ? AndroidUtils.resourceIDForAttribute(context, R.attr.spinnerItemBackground) : android.R.color.transparent;
+        row.setBackgroundColor(context.getColor(backgroundID));
         label.setGravity(Gravity.CENTER);
         return row;
     }

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -63,7 +63,7 @@
         <item name="emptyWandMipmap">@drawable/wand_empty</item>
         <item name="filledStarBW">@drawable/star_filled_grey</item>
         <item name="menuHeaderColor">@color/menuHeaderColor</item>
-        <item name="spinnerItemBackground">@android:color/transparent</item>
+        <item name="spinnerItemBackground">@color/lightBrown</item>
         <item name="alertDialogBackground">@color/lightBrown</item>
         <item name="alertDialogColorAccent">@color/darkBrown</item>
         <item name="preferenceBackground">@color/lightBrown</item>


### PR DESCRIPTION
This PR fixes an unintended issue caused by #150. Since those changes involved setting the decor view background to be black, we can no longer make the spinner item background be transparent in the parchment theme as this will leave the background black. This both doesn't match the theme and is basically unreadable with black text.

The approach here is to set different backgrounds for the "selected" spinner item (transparent) and the dropdown item. For consistency with the settings fragment, we make the background color for the parchment theme be our light brown.