### PR TITLE
Add ability to create spell shortcuts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
     <application
         android:name="dnd.jon.spellbook.SpellbookApplication"
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,6 +45,14 @@
             </intent-filter>
         </activity>
         <activity
+            android:name="dnd.jon.spellbook.ShortcutSpellWindowActivity"
+            android:exported="true"
+            >
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name="dnd.jon.spellbook.SpellcastingInfoWindow"
             android:exported="true"
             >

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,7 @@
         <activity
             android:name="dnd.jon.spellbook.ShortcutSpellWindowActivity"
             android:exported="true"
+            android:icon="@mipmap/ic_launcher_foreground"
             >
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/java/dnd/jon/spellbook/AndroidUtils.java
+++ b/app/src/main/java/dnd/jon/spellbook/AndroidUtils.java
@@ -21,8 +21,13 @@ import android.util.TypedValue;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
+import android.view.WindowInsetsController;
+import android.widget.FrameLayout;
 
 import androidx.annotation.RequiresApi;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 import org.javatuples.Pair;
 
@@ -96,5 +101,32 @@ class AndroidUtils {
                 dp,
                 context.getResources().getDisplayMetrics()
         );
+    }
+
+    static void applyDefaultWindowInsets(View rootView) {
+        ViewCompat.setOnApplyWindowInsetsListener(rootView, (view, windowInsets) -> {
+            final Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+
+            final FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) view.getLayoutParams();
+            params.topMargin = insets.top;
+            params.bottomMargin = insets.bottom;
+            view.setLayoutParams(params);
+
+            return WindowInsetsCompat.CONSUMED;
+        });
+    }
+
+
+    static void setupStatusBar(Activity activity) {
+        final View decorView = activity.getWindow().getDecorView();
+        decorView.setBackgroundColor(activity.getColor(android.R.color.black));
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            final WindowInsetsController controller = activity.getWindow().getInsetsController();
+            if (controller != null) {
+                controller.setSystemBarsAppearance(0, WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
+            }
+        }
+        decorView.setSystemUiVisibility(0);
     }
 }

--- a/app/src/main/java/dnd/jon/spellbook/CustomPopupWindow.java
+++ b/app/src/main/java/dnd/jon/spellbook/CustomPopupWindow.java
@@ -1,5 +1,6 @@
 package dnd.jon.spellbook;
 
+import android.app.Activity;
 import android.content.Context;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -9,43 +10,35 @@ import android.widget.PopupWindow;
 
 abstract class CustomPopupWindow {
 
-    final MainActivity main;
+    final Context activity;
     final View popupView;
     final PopupWindow popup;
 
     private static final boolean defaultFocusable = true;
 
-    CustomPopupWindow(MainActivity m, int layoutID, boolean focusable) {
-        main = m;
-        LayoutInflater inflater = (LayoutInflater) main.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+    CustomPopupWindow(Context activity, int layoutID, boolean focusable) {
+        this.activity = activity;
+        final LayoutInflater inflater = (LayoutInflater) activity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         popupView = inflater.inflate(layoutID, null);
-        //popup = new PopupWindow(popupView, width, height, focusable);
         popup = new PopupWindow(popupView, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT, focusable);
-        //popupContext = popupView.getContext();
         popup.setAnimationStyle(android.R.style.Animation_Dialog);
     }
 
-    CustomPopupWindow(MainActivity m, int layoutID) {
-        this(m, layoutID, defaultFocusable);
-    }
-
-    void show() {
-        popup.showAtLocation(popupView, Gravity.CENTER, 0, 0);
+    CustomPopupWindow(Context activity, int layoutID) {
+        this(activity, layoutID, defaultFocusable);
     }
 
     void showUnderView(View view) {
-        int[] viewLocation = new int[2];
+        final int[] viewLocation = new int[2];
         view.getLocationOnScreen(viewLocation);
-        int height = view.getHeight();
-        int x = viewLocation[0];
-        //int y = viewLocation[1] + (int) Math.round(height * 0.8);
-        int y = viewLocation[1] + height;
+        final int height = view.getHeight();
+        final int x = viewLocation[0];
+        final int y = viewLocation[1] + height;
         popup.showAtLocation(popupView, Gravity.TOP | Gravity.START, x, y);
     }
 
     void dismiss() {
         popup.dismiss();
     }
-
 
 }

--- a/app/src/main/java/dnd/jon/spellbook/CustomPopupWindow.java
+++ b/app/src/main/java/dnd/jon/spellbook/CustomPopupWindow.java
@@ -1,6 +1,5 @@
 package dnd.jon.spellbook;
 
-import android.app.Activity;
 import android.content.Context;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -10,15 +9,15 @@ import android.widget.PopupWindow;
 
 abstract class CustomPopupWindow {
 
-    final Context activity;
+    final Context context;
     final View popupView;
     final PopupWindow popup;
 
     private static final boolean defaultFocusable = true;
 
-    CustomPopupWindow(Context activity, int layoutID, boolean focusable) {
-        this.activity = activity;
-        final LayoutInflater inflater = (LayoutInflater) activity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+    CustomPopupWindow(Context context, int layoutID, boolean focusable) {
+        this.context = context;
+        final LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         popupView = inflater.inflate(layoutID, null);
         popup = new PopupWindow(popupView, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT, focusable);
         popup.setAnimationStyle(android.R.style.Animation_Dialog);

--- a/app/src/main/java/dnd/jon/spellbook/LocalizationUtils.java
+++ b/app/src/main/java/dnd/jon/spellbook/LocalizationUtils.java
@@ -47,11 +47,7 @@ public class LocalizationUtils {
     }};
 
     static Locale getLocale() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N){
-            return LocaleList.getDefault().get(0);
-        } else{
-            return Locale.getDefault();
-        }
+        return LocaleList.getDefault().get(0);
     }
 
     static Locale defaultSpellLocale() {

--- a/app/src/main/java/dnd/jon/spellbook/MainActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/MainActivity.java
@@ -216,16 +216,7 @@ public class MainActivity extends SpellbookActivity
         final View rootView = binding.getRoot();
         setContentView(rootView);
 
-        ViewCompat.setOnApplyWindowInsetsListener(rootView, (view, windowInsets) -> {
-            final Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
-
-            final FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) view.getLayoutParams();
-            params.topMargin = insets.top;
-            params.bottomMargin = insets.bottom;
-            view.setLayoutParams(params);
-
-            return WindowInsetsCompat.CONSUMED;
-        });
+        AndroidUtils.applyDefaultWindowInsets(rootView);
 
         spellWindowFragment = (SpellWindowFragment) getSupportFragmentManager().findFragmentByTag(SPELL_WINDOW_FRAGMENT_TAG);
 
@@ -565,7 +556,7 @@ public class MainActivity extends SpellbookActivity
         setupFAB();
         setupBottomNavBar();
         setupSideMenu();
-        setupStatusBar();
+        AndroidUtils.setupStatusBar(this);
         setupNavigationBar();
     }
 
@@ -1230,19 +1221,6 @@ public class MainActivity extends SpellbookActivity
         getWindow().setNavigationBarColor(getColor(color.white));
     }
 
-    private void setupStatusBar() {
-        final View decorView = getDecorView();
-        decorView.setBackgroundColor(getColor(android.R.color.black));
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            final WindowInsetsController controller = getWindow().getInsetsController();
-            if (controller != null) {
-                controller.setSystemBarsAppearance(0, WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS);
-            }
-        }
-        decorView.setSystemUiVisibility(0);
-    }
-
     private void openPlayStoreForRating() {
         final Uri uri = Uri.parse("market://details?id=" + getPackageName());
         final Intent goToPlayStore = new Intent(Intent.ACTION_VIEW, uri);
@@ -1664,11 +1642,7 @@ public class MainActivity extends SpellbookActivity
         }
     }
 
-    private View getDecorView() {
-        return getWindow().getDecorView();
-    }
-
-    //    @Override
+//    @Override
 //    public void onBackStackChanged() {
 //        shouldDisplayHomeUp();
 //    }

--- a/app/src/main/java/dnd/jon/spellbook/ShortcutSpellWindowActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/ShortcutSpellWindowActivity.java
@@ -22,6 +22,7 @@ public class ShortcutSpellWindowActivity extends SpellbookActivity {
 
     static final String SPELL_JSON_KEY = "spell_json";
     static final String CLOSE_ON_FINISH_KEY = "exit_on_close";
+    static final String LANGUAGE_KEY = "language";
     private static final String TAG = "shortcut_spell_window_activity";
 
     @Override
@@ -33,9 +34,7 @@ public class ShortcutSpellWindowActivity extends SpellbookActivity {
         setContentView(rootView);
         AndroidUtils.applyDefaultWindowInsets(rootView);
 
-        final Locale locale = SpellbookUtils.spellsLocale(this);
-        final Context context = LocalizationUtils.getLocalizedContext(this, locale);
-        binding.setContext(context);
+
 
         // Since the shortcut isn't associated with any particular character,
         // we set this to true so that we're giving all of the information
@@ -48,6 +47,20 @@ public class ShortcutSpellWindowActivity extends SpellbookActivity {
 
         // Set values from intent
         final Intent intent = getIntent();
+
+        Locale locale = null;
+        if (intent.hasExtra(LANGUAGE_KEY)) {
+            final String languageCode = intent.getStringExtra(LANGUAGE_KEY);
+            if (languageCode != null) {
+                locale = new Locale(languageCode);
+            }
+        }
+        if (locale == null) {
+            locale = SpellbookUtils.spellsLocale(this);
+        }
+        final Context context = LocalizationUtils.getLocalizedContext(this, locale);
+        binding.setContext(context);
+
         if (intent.hasExtra(SPELL_JSON_KEY)) {
             final String spellJsonString = intent.getStringExtra(SPELL_JSON_KEY);
             if (spellJsonString != null) {

--- a/app/src/main/java/dnd/jon/spellbook/ShortcutSpellWindowActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/ShortcutSpellWindowActivity.java
@@ -37,8 +37,12 @@ public class ShortcutSpellWindowActivity extends SpellbookActivity {
         final Context context = LocalizationUtils.getLocalizedContext(this, locale);
         binding.setContext(context);
 
-        // TODO: Make these respect current settings, in some form
+        // Since the shortcut isn't associated with any particular character,
+        // we set this to true so that we're giving all of the information
         binding.setUseExpanded(true);
+
+        // We don't really offer any way to change these yet, so for now we can just use defaults
+        // When we do offer a way to change these in the app settings, we'll want to respect that here
         binding.setTextColor(getColor(AndroidUtils.resourceIDForAttribute(this, R.attr.defaultTextColor)));
         binding.setTextSize(14);
 

--- a/app/src/main/java/dnd/jon/spellbook/ShortcutSpellWindowActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/ShortcutSpellWindowActivity.java
@@ -82,6 +82,12 @@ public class ShortcutSpellWindowActivity extends SpellbookActivity {
     }
 
     @Override
+    public void onStop() {
+        super.onStop();
+        this.finish();
+    }
+
+    @Override
     public void finish() {
         super.finish();
         if (closeOnFinish) {

--- a/app/src/main/java/dnd/jon/spellbook/ShortcutSpellWindowActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/ShortcutSpellWindowActivity.java
@@ -1,0 +1,73 @@
+package dnd.jon.spellbook;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.view.View;
+import android.os.Bundle;
+import android.util.Log;
+
+import androidx.preference.PreferenceManager;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Locale;
+
+import dnd.jon.spellbook.databinding.SpellWindowBinding;
+
+public class ShortcutSpellWindowActivity extends SpellbookActivity {
+
+    private boolean closeOnFinish = false;
+
+    static final String SPELL_JSON_KEY = "spell_json";
+    static final String CLOSE_ON_FINISH_KEY = "exit_on_close";
+    private static final String TAG = "shortcut_spell_window_activity";
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        final SpellWindowBinding binding = SpellWindowBinding.inflate(getLayoutInflater());
+
+        final View rootView = binding.getRoot();
+        setContentView(rootView);
+        AndroidUtils.applyDefaultWindowInsets(rootView);
+
+        final Locale locale = SpellbookUtils.spellsLocale(this);
+        final Context context = LocalizationUtils.getLocalizedContext(this, locale);
+        binding.setContext(context);
+
+        // TODO: Make these respect current settings, in some form
+        binding.setUseExpanded(true);
+        binding.setTextColor(getColor(AndroidUtils.resourceIDForAttribute(this, R.attr.defaultTextColor)));
+        binding.setTextSize(14);
+
+        // Set values from intent
+        final Intent intent = getIntent();
+        if (intent.hasExtra(SPELL_JSON_KEY)) {
+            final String spellJsonString = intent.getStringExtra(SPELL_JSON_KEY);
+            if (spellJsonString != null) {
+                final SpellCodec codec = new SpellCodec(this);
+                try {
+                    final JSONObject json = new JSONObject(spellJsonString);
+                    final SpellBuilder builder = new SpellBuilder(this);
+                    final Spell spell = codec.parseSpell(json, builder, false);
+                    binding.setSpell(spell);
+                    binding.spellWindowButtonGroup.setVisibility(View.GONE);
+                } catch (JSONException e) {
+                    Log.e(TAG, e.getLocalizedMessage());
+                }
+            }
+        }
+
+        closeOnFinish = intent.getBooleanExtra(CLOSE_ON_FINISH_KEY, false);
+    }
+
+    @Override
+    public void finish() {
+        super.finish();
+        if (closeOnFinish) {
+            finishAffinity();
+        }
+    }
+}

--- a/app/src/main/java/dnd/jon/spellbook/ShortcutSpellWindowActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/ShortcutSpellWindowActivity.java
@@ -60,6 +60,7 @@ public class ShortcutSpellWindowActivity extends SpellbookActivity {
                     binding.spellWindowButtonGroup.setVisibility(View.GONE);
                 } catch (JSONException e) {
                     Log.e(TAG, e.getLocalizedMessage());
+                    this.finish();
                 }
             }
         }

--- a/app/src/main/java/dnd/jon/spellbook/SpellAdapter.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellAdapter.java
@@ -39,7 +39,7 @@ public class SpellAdapter extends RecyclerView.Adapter<SpellAdapter.SpellRowHold
             this.viewModel = viewModel;
             itemView.setTag(this);
             itemView.setOnClickListener(listener);
-            //itemView.setOnLongClickListener(longListener);
+            itemView.setOnLongClickListener(longListener);
         }
 
         public void bind(Spell s) {
@@ -76,13 +76,9 @@ public class SpellAdapter extends RecyclerView.Adapter<SpellAdapter.SpellRowHold
     // Also the list of spells, and the click listeners
     private List<Spell> spells;
     private final View.OnClickListener listener;
+    private final View.OnLongClickListener longListener;
     private final SpellbookViewModel viewModel;
-//    private final View.OnLongClickListener longListener = (View view) -> {
-//        final SpellRowHolder srh = (SpellRowHolder) view.getTag();
-//        final Spell spell = srh.getSpell();
-//        main.openSpellPopup(view, spell);
-//        return true;
-//    };
+
 
     // Constructor from the list of spells
     SpellAdapter(SpellbookViewModel viewModel) {
@@ -92,6 +88,14 @@ public class SpellAdapter extends RecyclerView.Adapter<SpellAdapter.SpellRowHold
             final SpellRowHolder srh = (SpellRowHolder) view.getTag();
             final Spell spell = srh.getSpell();
             this.viewModel.setCurrentSpell(spell);
+        };
+
+        this.longListener = (View view) -> {
+            final SpellRowHolder srh = (SpellRowHolder) view.getTag();
+            final Spell spell = srh.getSpell();
+            final SpellShortcutPopup popup = new SpellShortcutPopup(view.getContext(), spell);
+            popup.showUnderView(view);
+            return true;
         };
     }
 

--- a/app/src/main/java/dnd/jon/spellbook/SpellShortcutPopup.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellShortcutPopup.java
@@ -1,0 +1,17 @@
+package dnd.jon.spellbook;
+
+import android.app.Activity;
+import android.content.Context;
+import android.view.View;
+import android.widget.Button;
+
+
+public class SpellShortcutPopup extends CustomPopupWindow {
+    private static final int layoutID = R.layout.spell_shortcut_popup;
+
+    SpellShortcutPopup(Context activity, Spell spell) {
+        super(activity, layoutID, true);
+        final Button button = popupView.findViewById(R.id.create_spell_shortcut_button);
+        button.setOnClickListener((View view) -> SpellbookUtils.createShortcut(activity, spell));
+    }
+}

--- a/app/src/main/java/dnd/jon/spellbook/SpellShortcutPopup.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellShortcutPopup.java
@@ -2,6 +2,7 @@ package dnd.jon.spellbook;
 
 import android.content.Context;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.Toast;
 
@@ -9,14 +10,27 @@ import android.widget.Toast;
 public class SpellShortcutPopup extends CustomPopupWindow {
     private static final int layoutID = R.layout.spell_shortcut_popup;
 
-    SpellShortcutPopup(Context activity, Spell spell) {
-        super(activity, layoutID, true);
+    SpellShortcutPopup(Context context, Spell spell) {
+        super(context, layoutID, true);
         final Button button = popupView.findViewById(R.id.create_spell_shortcut_button);
+
         button.setOnClickListener((View view) -> {
-            SpellbookUtils.createShortcut(activity, spell);
-            final Context context = view.getContext();
-            Toast.makeText(context, context.getString(R.string.shortcut_created_toast, spell.getName()), Toast.LENGTH_SHORT).show();
+            SpellbookUtils.createShortcut(context, spell);
+            final Context ctx = view.getContext();
+            Toast.makeText(ctx, context.getString(R.string.shortcut_created_toast, spell.getName()), Toast.LENGTH_SHORT).show();
             this.dismiss();
         });
+    }
+
+    @Override
+    public void showUnderView(View view) {
+        super.showUnderView(view);
+
+        final View container = (View) popup.getContentView().getParent();
+        final WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+        final WindowManager.LayoutParams params = (WindowManager.LayoutParams) container.getLayoutParams();
+        params.flags |= WindowManager.LayoutParams.FLAG_DIM_BEHIND;
+        params.dimAmount = 0.3f;
+        wm.updateViewLayout(container, params);
     }
 }

--- a/app/src/main/java/dnd/jon/spellbook/SpellShortcutPopup.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellShortcutPopup.java
@@ -1,6 +1,5 @@
 package dnd.jon.spellbook;
 
-import android.app.Activity;
 import android.content.Context;
 import android.view.View;
 import android.widget.Button;

--- a/app/src/main/java/dnd/jon/spellbook/SpellShortcutPopup.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellShortcutPopup.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.view.View;
 import android.widget.Button;
+import android.widget.Toast;
 
 
 public class SpellShortcutPopup extends CustomPopupWindow {
@@ -12,6 +13,11 @@ public class SpellShortcutPopup extends CustomPopupWindow {
     SpellShortcutPopup(Context activity, Spell spell) {
         super(activity, layoutID, true);
         final Button button = popupView.findViewById(R.id.create_spell_shortcut_button);
-        button.setOnClickListener((View view) -> SpellbookUtils.createShortcut(activity, spell));
+        button.setOnClickListener((View view) -> {
+            SpellbookUtils.createShortcut(activity, spell);
+            final Context context = view.getContext();
+            Toast.makeText(context, context.getString(R.string.shortcut_created_toast, spell.getName()), Toast.LENGTH_SHORT).show();
+            this.dismiss();
+        });
     }
 }

--- a/app/src/main/java/dnd/jon/spellbook/SpellStatusPopup.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellStatusPopup.java
@@ -20,33 +20,33 @@ class SpellStatusPopup extends CustomPopupWindow {
         favoriteIB = popupView.findViewById(R.id.status_popup_favorite);
         preparedIB = popupView.findViewById(R.id.status_popup_prepared);
         knownIB = popupView.findViewById(R.id.status_popup_known);
-        final SpellFilterStatus status = main.getSpellFilterStatus();
+        final SpellFilterStatus status = mainActivity.getSpellFilterStatus();
         setFavoriteIcon(status.isFavorite(spell));
         setPreparedIcon(status.isPrepared(spell));
         setKnownIcon(status.isKnown(spell));
 
         // Set the button listeners
         favoriteIB.setOnClickListener((View v) -> {
-            final SpellFilterStatus sfs = main.getSpellFilterStatus();
+            final SpellFilterStatus sfs = mainActivity.getSpellFilterStatus();
             final boolean nowFavorite = !sfs.isFavorite(spell);
             sfs.setFavorite(spell, nowFavorite);
             setFavoriteIcon(nowFavorite);
         });
         preparedIB.setOnClickListener((View v) -> {
-            final SpellFilterStatus sfs = main.getSpellFilterStatus();
+            final SpellFilterStatus sfs = mainActivity.getSpellFilterStatus();
             final boolean nowPrepared = !sfs.isPrepared(spell);
             sfs.setPrepared(spell, nowPrepared);
             setPreparedIcon(nowPrepared);
         });
         knownIB.setOnClickListener((View v) -> {
-            final SpellFilterStatus sfs = main.getSpellFilterStatus();
+            final SpellFilterStatus sfs = mainActivity.getSpellFilterStatus();
             final boolean nowKnown = !sfs.isKnown(spell);
             sfs.setKnown(spell, nowKnown);
             setKnownIcon(nowKnown);
         });
 
         // Set the OnDismissListener
-        popup.setOnDismissListener(main::saveCharacterProfile);
+        popup.setOnDismissListener(mainActivity::saveCharacterProfile);
 
         // Set the elevation
         popup.setElevation(10);

--- a/app/src/main/java/dnd/jon/spellbook/SpellWindow.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellWindow.java
@@ -1,6 +1,5 @@
 package dnd.jon.spellbook;
 
-import android.util.Log;
 import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.ViewModelProvider;
@@ -8,9 +7,6 @@ import androidx.lifecycle.ViewModelProvider;
 import android.os.Bundle;
 import android.app.Activity;
 import android.content.Intent;
-
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import dnd.jon.spellbook.databinding.SpellWindowActivityBinding;
 
@@ -20,15 +16,12 @@ public final class SpellWindow extends SpellbookActivity {
     private ViewModelProvider.Factory viewModelFactory;
 
     static final String SPELL_KEY = "spell";
-    static final String SPELL_JSON_KEY = "spell_json";
     static final String TEXT_SIZE_KEY = "textSize";
     static final String INDEX_KEY = "index";
     static final String FAVORITE_KEY = "favorite";
     static final String KNOWN_KEY = "known";
     static final String PREPARED_KEY = "prepared";
     static final String USE_EXPANDED_KEY = "use_expanded";
-    static final String BUTTONS_KEY = "show_buttons";
-    static final String CLOSE_ON_FINISH_KEY = "exit_on_close";
 
     private static final String FRAGMENT_TAG = "spell_window_fragment";
     private static final String TAG = "spell_window_activity";
@@ -36,7 +29,6 @@ public final class SpellWindow extends SpellbookActivity {
     private Intent returnIntent;
     private SpellWindowActivityBinding binding;
     private SpellWindowFragment fragment;
-    private boolean closeOnFinish = false;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -50,18 +42,6 @@ public final class SpellWindow extends SpellbookActivity {
         Spell spell = null;
         if (intent.hasExtra(SPELL_KEY)) {
             spell = intent.getParcelableExtra(SPELL_KEY);
-        } else if (intent.hasExtra(SPELL_JSON_KEY)) {
-            final String spellJsonString = intent.getStringExtra(SPELL_JSON_KEY);
-            if (spellJsonString != null) {
-                final SpellCodec codec = new SpellCodec(this);
-                try {
-                    final JSONObject json = new JSONObject(spellJsonString);
-                    final SpellBuilder builder = new SpellBuilder(this);
-                    spell = codec.parseSpell(json, builder, false);
-                } catch (JSONException e) {
-                    Log.e(TAG, e.getLocalizedMessage());
-                }
-            }
         }
         final int index = intent.getIntExtra(INDEX_KEY,-1);
         final boolean useExpanded = intent.getBooleanExtra(USE_EXPANDED_KEY, false);
@@ -69,8 +49,6 @@ public final class SpellWindow extends SpellbookActivity {
         boolean favorite = intent.getBooleanExtra(FAVORITE_KEY, false);
         boolean prepared = intent.getBooleanExtra(PREPARED_KEY, false);
         boolean known = intent.getBooleanExtra(KNOWN_KEY, false);
-        boolean showButtons = intent.getBooleanExtra(BUTTONS_KEY, false);
-        closeOnFinish = intent.getBooleanExtra(CLOSE_ON_FINISH_KEY, false);
 
         final SpellStatus status = new SpellStatus(favorite, prepared, known);
 
@@ -85,11 +63,6 @@ public final class SpellWindow extends SpellbookActivity {
                 .beginTransaction()
                 .setReorderingAllowed(true)
                 .add(R.id.spell_window_fragment_container, fragment, FRAGMENT_TAG)
-                .runOnCommit(() -> {
-                    if (!showButtons) {
-                        fragment.binding.spellWindowButtonGroup.setVisibility(View.GONE);
-                    }
-                })
                 .commit();
 
         // Create the return intent
@@ -144,9 +117,6 @@ public final class SpellWindow extends SpellbookActivity {
     public void finish() {
         super.finish();
         overridePendingTransition(R.anim.identity, R.anim.left_to_right_exit);
-        if (closeOnFinish) {
-            finishAffinity();
-        }
     }
 
     @NonNull

--- a/app/src/main/java/dnd/jon/spellbook/SpellbookActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellbookActivity.java
@@ -1,5 +1,6 @@
 package dnd.jon.spellbook;
 
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.ViewGroup;
@@ -20,6 +21,7 @@ public class SpellbookActivity extends AppCompatActivity {
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        final Intent intent = getIntent();
         final int theme = SpellbookUtils.themeForPreferences(this, prefs);
         // No need to recreate the theme here, as the content view hasn't been set up
         // In fact, if we do recreate, we end up in an endless loop

--- a/app/src/main/java/dnd/jon/spellbook/SpellbookActivity.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellbookActivity.java
@@ -30,6 +30,8 @@ public class SpellbookActivity extends AppCompatActivity {
         // and not have to maintain two layouts
         EdgeToEdge.enable(this);
 
+        AndroidUtils.setupStatusBar(this);
+
         super.onCreate(savedInstanceState);
     }
 

--- a/app/src/main/java/dnd/jon/spellbook/SpellbookFragment.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellbookFragment.java
@@ -9,6 +9,7 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.preference.PreferenceManager;
 import androidx.viewbinding.ViewBinding;

--- a/app/src/main/java/dnd/jon/spellbook/SpellbookFragment.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellbookFragment.java
@@ -11,7 +11,6 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.ViewModelProvider;
-import androidx.preference.PreferenceManager;
 import androidx.viewbinding.ViewBinding;
 
 public abstract class SpellbookFragment<VB extends ViewBinding> extends Fragment {

--- a/app/src/main/java/dnd/jon/spellbook/SpellbookUtils.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellbookUtils.java
@@ -376,7 +376,13 @@ public class SpellbookUtils {
             Log.e(TAG, e.getLocalizedMessage());
             return null;
         }
+
+        final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        final String languageKey = context.getString(R.string.spell_language_key);
+        final String language = preferences.getString(languageKey, context.getString(R.string.english_code));
+
         intent.setAction(Intent.ACTION_VIEW);
+        intent.putExtra(languageKey, language);
         intent.putExtra(ShortcutSpellWindowActivity.SPELL_JSON_KEY, spellJson);
         intent.putExtra(ShortcutSpellWindowActivity.CLOSE_ON_FINISH_KEY, true);
         return intent;
@@ -388,9 +394,10 @@ public class SpellbookUtils {
             return;
         }
         final ShortcutInfoCompat shortcut = new ShortcutInfoCompat.Builder(context, spell.getName())
-                .setLongLabel("Open " + spell.getName())
+                .setLongLabel(spell.getName())
                 .setShortLabel(spell.getName())
                 .setIcon(IconCompat.createWithResource(context, R.drawable.book_icon))
+                .setAlwaysBadged()
                 .setIntent(intent)
                 .build();
 

--- a/app/src/main/res/drawable/colored_bg_bordered.xml
+++ b/app/src/main/res/drawable/colored_bg_bordered.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <!-- background -->
+            <solid android:color="?attr/solidBackgroundColor" />
+            <!-- border -->
+            <stroke android:width="1dp" android:color="?attr/defaultTextColor" />
+
+            <!-- corner roundness -->
+            <corners android:radius="8dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/spell_shortcut_popup.xml
+++ b/app/src/main/res/layout/spell_shortcut_popup.xml
@@ -5,19 +5,6 @@
     android:layout_height="match_parent"
     >
 
-    <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/spell_status_popup_background"
-        android:background="@android:color/transparent"
-        android:src="?attr/background"
-        android:layout_alignTop="@id/spell_shortcut_internal_ll"
-        android:layout_alignBottom="@id/spell_shortcut_internal_ll"
-        android:layout_alignStart="@id/spell_shortcut_internal_ll"
-        android:layout_alignEnd="@id/spell_shortcut_internal_ll"
-        android:scaleType="fitXY"
-        />
-
     <LinearLayout
         android:id="@+id/spell_shortcut_internal_ll"
         android:layout_width="wrap_content"
@@ -30,7 +17,7 @@
            android:text="@string/create_spell_shortcut"
            android:paddingVertical="9dp"
            android:paddingHorizontal="9dp"
-           android:background="@drawable/transparent_bg_bordered_button"
+           android:background="@drawable/colored_bg_bordered"
            android:foreground="?android:attr/selectableItemBackground"
            />
     </LinearLayout>

--- a/app/src/main/res/layout/spell_shortcut_popup.xml
+++ b/app/src/main/res/layout/spell_shortcut_popup.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    >
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/spell_status_popup_background"
+        android:background="@android:color/transparent"
+        android:src="?attr/background"
+        android:layout_alignTop="@id/spell_shortcut_internal_ll"
+        android:layout_alignBottom="@id/spell_shortcut_internal_ll"
+        android:layout_alignStart="@id/spell_shortcut_internal_ll"
+        android:layout_alignEnd="@id/spell_shortcut_internal_ll"
+        android:scaleType="fitXY"
+        />
+
+    <LinearLayout
+        android:id="@+id/spell_shortcut_internal_ll"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        >
+       <Button
+           android:id="@+id/create_spell_shortcut_button"
+           android:layout_width="wrap_content"
+           android:layout_height="wrap_content"
+           android:text="@string/create_spell_shortcut"
+           android:paddingVertical="9dp"
+           android:paddingHorizontal="9dp"
+           android:background="@drawable/transparent_bg_bordered_button"
+           />
+    </LinearLayout>
+
+
+
+</RelativeLayout>

--- a/app/src/main/res/layout/spell_shortcut_popup.xml
+++ b/app/src/main/res/layout/spell_shortcut_popup.xml
@@ -31,6 +31,7 @@
            android:paddingVertical="9dp"
            android:paddingHorizontal="9dp"
            android:background="@drawable/transparent_bg_bordered_button"
+           android:foreground="?android:attr/selectableItemBackground"
            />
     </LinearLayout>
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -80,6 +80,9 @@
     <string name="character_selection_message">Selecione um personagem</string>
     <string name="create_new_character">Crie um novo personagem</string>
 
+    <!-- Spell shortcut popup -->
+    <string name="create_spell_shortcut">Criar atalho</string>
+
     <!-- Source management dialog -->
     <string name="source_management_title">Fontes Criadas</string>
     <string name="source_selection_message">Selecione uma fonte</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -466,6 +466,7 @@
     <string name="status_selected_toast">Configuração selecionada: %1$s</string>
     <string name="character_load_error">Erro ao carregar o perfil do personagem: %1$s</string>
     <string name="character_export_error">Erro ao exportar JSON de caractere: %1$s</string>
+    <string name="shortcut_created_toast">Atalho criado para %1$s</string>
 
     <!-- Filter options -->
     <string name="filter_options_title">Opções de Filtro</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -469,6 +469,7 @@
     <string name="status_selected_toast">Configuration selected: %1$s</string>
     <string name="character_load_error">Error loading character profile: %1$s</string>
     <string name="character_export_error">Error exporting character JSON: %1$s</string>
+    <string name="shortcut_created_toast">Created shortcut for %1$s</string>
 
     <!-- Filter options -->
     <string name="filter_options_title">Filter Options</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,6 +81,9 @@
     <string name="character_selection_message">Please select a character</string>
     <string name="create_new_character">Create new character</string>
 
+    <!-- Spell shortcut popup -->
+    <string name="create_spell_shortcut">Create shortcut</string>
+
     <!-- Source management dialog -->
     <string name="source_management_title">Created Sources</string>
     <string name="source_selection_message">Please select a source</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -21,6 +21,7 @@
     <attr name="menuHeaderColor" format="reference"/>
     <attr name="upDownArrow" format="reference"/>
     <attr name="fastScrollThumbColor" format="reference"/>
+    <attr name="solidBackgroundColor" format="reference"/>
 
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.NoActionBar">
@@ -68,6 +69,7 @@
         <item name="alertDialogColorAccent">@color/darkBrown</item>
         <item name="preferenceBackground">@color/lightBrown</item>
         <item name="fastScrollThumbColor">@color/darkBrown</item>
+        <item name="solidBackgroundColor">@color/lightBrown</item>
     </style>
 
     <style name="DarkAppTheme" parent="AppTheme">
@@ -89,6 +91,7 @@
         <item name="alertDialogColorAccent">@color/lightBrown</item>
         <item name="preferenceBackground">@color/darkGray</item>
         <item name="fastScrollThumbColor">@color/lightBrown</item>
+        <item name="solidBackgroundColor">@color/darkGray</item>
     </style>
 
     <style name="LightAppTheme" parent="AppTheme">
@@ -109,6 +112,7 @@
         <item name="alertDialogColorAccent">@color/darkBrown</item>
         <item name="preferenceBackground">@color/lightBrown</item>
         <item name="fastScrollThumbColor">@color/darkBrown</item>
+        <item name="solidBackgroundColor">@color/lightBrown</item>
     </style>
 
     <!-- Custom spinner theme


### PR DESCRIPTION
This PR implements a feature that I've wanted ot add for a while, which is to allow creating [dynamic shortcuts](https://developer.android.com/develop/ui/views/launch/shortcuts/creating-shortcuts) for particular spells. The nice thing about these is that they can actually be "popped off" and put on the home screen as a separate icon.

This ended up being less straightforward than I expected - not so much in the implementation, but in the app flow choices to make. I decided that, to make the shortcuts as simple as possible, that the opened view shouldn't have any relation to the overall app state. Thus, this creates a new activity which uses the existing spell window layout but hides the spell list and cast buttons. Additionally, we include the spell (in JSON form) in the shortcut intent. These two items together means that we don't need to load any of the overall app information (we don't even need to do things like load the spell list file), which should make the shortcut much speedier.

As for behavior, closing the shortcut will just bring the user back to the home screen. I also wanted to make sure that clicking the regular app icon will always open the app proper, so we actually close the shortcut activity in its `onStop` method.

The other main choice to make here is how to create a shortcut, which I don't think has an obvious option. Currently long-pressing on a spell in the table will open a small popup window (which has a scrim to highlight it) with a button to create a shortcut. I debated just opening an alert dialog, which will probably be the route I'll go anyway if more options get added to the long-press, but for now I think the popup is simpler.