### PR TITLE
Fixes for spellcasting window

### DIFF
--- a/app/src/main/java/dnd/jon/spellbook/SpellcastingInfoWindow.java
+++ b/app/src/main/java/dnd/jon/spellbook/SpellcastingInfoWindow.java
@@ -29,7 +29,10 @@ public final class SpellcastingInfoWindow extends SpellbookActivity {
 
         super.onCreate(savedInstanceState);
         final SpellcastingInfoActivityLayoutBinding binding = SpellcastingInfoActivityLayoutBinding.inflate(getLayoutInflater());
-        setContentView(binding.getRoot());
+        final View rootView = binding.getRoot();
+        setContentView(rootView);
+
+        AndroidUtils.applyDefaultWindowInsets(rootView);
 
         // Get values from intent
         final Intent intent = getIntent();

--- a/app/src/main/res/values-pt/spellcasting_info.xml
+++ b/app/src/main/res/values-pt/spellcasting_info.xml
@@ -324,9 +324,9 @@
         Magias como mãos flamejantes e cone de frio cobrem
         uma área, permitindo afetar múltiplas criaturas de uma
         só vez.
-        A descrição da magia especifica sua área de efeito, a
-        qual tem normalmente uma das cinco formas: cone, cubo,
-        cilindro, linha, ou esfera. Toda área de efeito tem um
+        A descrição de uma magia especifica sua área de efeito,
+        que normalmente tem um dos cinco formatos diferentes:
+        cone, cubo, cilindro, linha ou esfera. Toda área de efeito tem um
         ponto de origem, uma localização de onde a magia
         irrompe. As regras para cada forma especificam como
         você posiciona seu ponto de origem. Normalmente, um

--- a/app/src/main/res/values/spellcasting_info.xml
+++ b/app/src/main/res/values/spellcasting_info.xml
@@ -289,8 +289,8 @@
     <string name="areas_of_effect">
         Spells such as <i>burning hands</i> and <i>cone of cold</i> cover an
         area, allowing them to affect multiple creatures at once.
-        \n\tA spell\'s description specifies its area af effect,
-        which typically has ane of five different shapes: cone,
+        \n\tA spell\'s description specifies its area of effect,
+        which typically has one of five different shapes: cone,
         cube, cylinder, line, or sphere. Every area of effect has
         a <b>point of origin</b>, a location from which the spell\'s
         energy erupts. The roles for each shape specify how you position


### PR DESCRIPTION
This PR makes a couple of small fixes to the spellcasting info:
* Fix some typos in the Areas of Effect text
* Apply the same insets to the spellcasting window activity that were added to the rest of the app in #150