### PR TITLE
Update 2024 Artificer spell list

### DIFF
--- a/app/src/main/assets/Spells_en.json
+++ b/app/src/main/assets/Spells_en.json
@@ -16525,6 +16525,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Wizard"
         ],
@@ -16551,6 +16552,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Cleric",
             "Druid",
@@ -16582,6 +16584,7 @@
     {
         "casting_time": "1 minute or Ritual",
         "classes": [
+            "Artificer",
             "Ranger",
             "Wizard"
         ],
@@ -16609,6 +16612,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Wizard"
         ],
@@ -16745,6 +16749,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Sorcerer",
             "Wizard"
@@ -16854,6 +16859,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Wizard"
         ],
         "components": [
@@ -16908,6 +16914,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Wizard"
         ],
         "components": [
@@ -16934,6 +16941,7 @@
     {
         "casting_time": "Bonus Action",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Wizard"
         ],
@@ -17391,6 +17399,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Wizard"
         ],
@@ -17581,6 +17590,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Wizard"
         ],
@@ -17606,6 +17616,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Wizard"
         ],
@@ -17879,6 +17890,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Cleric",
             "Paladin",
             "Wizard"
@@ -18550,6 +18562,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Cleric",
             "Druid",
             "Wizard"
@@ -18688,6 +18701,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Cleric",
             "Paladin"
         ],
@@ -18770,6 +18784,7 @@
     {
         "casting_time": "1 minute",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Wizard"
         ],
@@ -18850,6 +18865,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Cleric",
             "Druid",
@@ -18879,6 +18895,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Sorcerer",
             "Wizard"
@@ -18936,6 +18953,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Druid",
             "Ranger",
             "Sorcerer",
@@ -19121,6 +19139,7 @@
     {
         "casting_time": "Action or Ritual",
         "classes": [
+            "Artificer",
             "Bard",
             "Cleric",
             "Druid",
@@ -19238,6 +19257,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Sorcerer",
             "Wizard"
@@ -19320,6 +19340,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Cleric",
             "Druid",
@@ -19560,6 +19581,7 @@
     {
         "casting_time": "Bonus Action",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Wizard"
         ],
@@ -19721,6 +19743,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Druid",
             "Sorcerer",
             "Wizard"
@@ -19747,6 +19770,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Druid",
             "Paladin",
             "Ranger"
@@ -19775,6 +19799,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Cleric",
             "Druid",
@@ -19808,6 +19833,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Druid",
             "Sorcerer",
@@ -19971,6 +19997,7 @@
     {
         "casting_time": "Bonus Action",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Warlock",
             "Wizard"
@@ -20026,6 +20053,7 @@
     {
         "casting_time": "10 minutes",
         "classes": [
+            "Artificer",
             "Wizard"
         ],
         "components": [
@@ -20050,6 +20078,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Druid"
         ],
@@ -20075,6 +20104,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Wizard"
         ],
@@ -20133,6 +20163,7 @@
     {
         "casting_time": "Reaction, which you take when you or a creature you can see within 60 feet of you falls",
         "classes": [
+            "Artificer",
             "Bard",
             "Sorcerer",
             "Wizard"
@@ -20349,6 +20380,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Wizard"
         ],
@@ -20544,6 +20576,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Warlock",
             "Wizard"
@@ -20713,6 +20746,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Cleric",
             "Druid",
@@ -20967,6 +21001,7 @@
     {
         "casting_time": "1 hour",
         "classes": [
+            "Artificer",
             "Bard",
             "Cleric",
             "Wizard"
@@ -21050,6 +21085,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Wizard"
         ],
@@ -21104,6 +21140,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Cleric",
             "Druid",
@@ -21184,6 +21221,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Cleric",
             "Druid"
         ],
@@ -21368,6 +21406,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Wizard"
         ],
@@ -21448,6 +21487,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Druid"
         ],
@@ -21815,6 +21855,7 @@
     {
         "casting_time": "1 minute or Ritual",
         "classes": [
+            "Artificer",
             "Bard",
             "Wizard"
         ],
@@ -21978,6 +22019,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Sorcerer",
             "Warlock",
@@ -22038,6 +22080,7 @@
     {
         "casting_time": "Bonus Action",
         "classes": [
+            "Artificer",
             "Druid",
             "Ranger",
             "Sorcerer",
@@ -22121,6 +22164,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Wizard"
         ],
         "components": [
@@ -22174,6 +22218,7 @@
     {
         "casting_time": "Bonus Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Cleric",
             "Druid",
@@ -22202,6 +22247,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Wizard"
         ],
@@ -22230,6 +22276,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Cleric",
             "Sorcerer",
@@ -22403,6 +22450,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Druid",
             "Ranger",
@@ -22460,6 +22508,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Sorcerer",
             "Warlock",
@@ -22569,6 +22618,7 @@
     {
         "casting_time": "1 minute or Ritual",
         "classes": [
+            "Artificer",
             "Bard",
             "Wizard"
         ],
@@ -22596,6 +22646,7 @@
     {
         "casting_time": "Bonus Action",
         "classes": [
+            "Artificer",
             "Paladin",
             "Ranger",
             "Sorcerer",
@@ -22867,6 +22918,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Druid",
             "Sorcerer",
@@ -23185,6 +23237,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Wizard"
         ],
         "components": [
@@ -23238,6 +23291,7 @@
     {
         "casting_time": "10 minutes",
         "classes": [
+            "Artificer",
             "Wizard"
         ],
         "components": [
@@ -23404,6 +23458,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Wizard"
         ],
         "components": [
@@ -23701,6 +23756,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Druid",
             "Sorcerer",
             "Warlock",
@@ -23884,6 +23940,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Sorcerer",
             "Warlock",
@@ -24043,6 +24100,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Cleric",
             "Druid",
             "Ranger",
@@ -24103,6 +24161,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Cleric",
             "Druid",
             "Paladin",
@@ -24130,6 +24189,7 @@
     {
         "casting_time": "Action or Ritual",
         "classes": [
+            "Artificer",
             "Cleric",
             "Druid",
             "Paladin"
@@ -24237,6 +24297,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Wizard"
         ],
@@ -24370,6 +24431,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Cleric",
             "Druid"
         ],
@@ -24452,6 +24514,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Cleric",
             "Druid",
             "Paladin",
@@ -24481,6 +24544,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Wizard"
         ],
         "components": [
@@ -24532,6 +24596,7 @@
     {
         "casting_time": "Bonus Action",
         "classes": [
+            "Artificer",
             "Cleric"
         ],
         "components": [
@@ -24639,6 +24704,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Sorcerer",
             "Wizard"
@@ -24909,6 +24975,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Wizard"
         ],
@@ -25129,6 +25196,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Cleric",
             "Druid"
         ],
@@ -25236,6 +25304,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Warlock",
             "Wizard"
@@ -25453,6 +25522,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Cleric",
             "Druid",
             "Wizard"
@@ -25481,6 +25551,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Druid",
             "Ranger",
             "Sorcerer",
@@ -25652,6 +25723,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Wizard"
         ],
         "components": [
@@ -26180,6 +26252,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Druid"
         ],
         "components": [
@@ -26207,6 +26280,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Druid",
             "Sorcerer",
@@ -26503,6 +26577,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Bard",
             "Sorcerer",
             "Warlock",
@@ -26750,6 +26825,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Druid",
             "Sorcerer",
             "Wizard"
@@ -26834,6 +26910,7 @@
     {
       "casting_time": "Action or Ritual",
       "classes": [
+          "Artificer",
           "Druid",
           "Ranger",
           "Sorcerer",
@@ -26863,6 +26940,7 @@
     {
         "casting_time": "Action or Ritual",
         "classes": [
+            "Artificer",
             "Cleric",
             "Druid",
             "Ranger",
@@ -26892,6 +26970,7 @@
     {
         "casting_time": "Action",
         "classes": [
+            "Artificer",
             "Sorcerer",
             "Wizard"
         ],

--- a/app/src/main/assets/Spells_pt.json
+++ b/app/src/main/assets/Spells_pt.json
@@ -15417,6 +15417,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Mago"
         ],
@@ -15443,6 +15444,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Clérigo",
             "Druida",
@@ -15474,6 +15476,7 @@
     {
         "casting_time": "1 minuto ou Ritual",
         "classes": [
+            "Artífice",
             "Patrulheiro",
             "Mago"
         ],
@@ -15501,6 +15504,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Mago"
         ],
@@ -15637,6 +15641,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Feiticeiro",
             "Mago"
@@ -15746,6 +15751,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Mago"
         ],
         "components": [
@@ -15800,6 +15806,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Mago"
         ],
         "components": [
@@ -15826,6 +15833,7 @@
     {
         "casting_time": "Ação bônus",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Mago"
         ],
@@ -16283,6 +16291,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Mago"
         ],
@@ -16473,6 +16482,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Mago"
         ],
@@ -16498,6 +16508,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Mago"
         ],
@@ -16771,6 +16782,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Clérigo",
             "Paladino",
             "Mago"
@@ -17442,6 +17454,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Clérigo",
             "Druida",
             "Mago"
@@ -17580,6 +17593,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Clérigo",
             "Paladino"
         ],
@@ -17662,6 +17676,7 @@
     {
         "casting_time": "1 minuto",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Mago"
         ],
@@ -17742,6 +17757,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Clérigo",
             "Druida",
@@ -17771,6 +17787,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Feiticeiro",
             "Mago"
@@ -17828,6 +17845,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Druida",
             "Patrulheiro",
             "Feiticeiro",
@@ -18013,6 +18031,7 @@
     {
         "casting_time": "Ação ou Ritual",
         "classes": [
+            "Artífice",
             "Bardo",
             "Clérigo",
             "Druida",
@@ -18130,6 +18149,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Feiticeiro",
             "Mago"
@@ -18212,6 +18232,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Clérigo",
             "Druida",
@@ -18452,6 +18473,7 @@
     {
         "casting_time": "Ação bônus",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Mago"
         ],
@@ -18613,6 +18635,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Druida",
             "Feiticeiro",
             "Mago"
@@ -18639,6 +18662,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Druida",
             "Paladino",
             "Patrulheiro"
@@ -18667,6 +18691,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Clérigo",
             "Druida",
@@ -18700,6 +18725,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Druida",
             "Feiticeiro",
@@ -18863,6 +18889,7 @@
     {
         "casting_time": "Ação bônus",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Bruxo",
             "Mago"
@@ -18918,6 +18945,7 @@
     {
         "casting_time": "10 minutos",
         "classes": [
+            "Artífice",
             "Mago"
         ],
         "components": [
@@ -18942,6 +18970,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Druida"
         ],
@@ -18967,6 +18996,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Mago"
         ],
@@ -19025,6 +19055,7 @@
     {
         "casting_time": "Reação, que você toma quando você ou uma criatura que você pode ver a até 60 pés de você cai",
         "classes": [
+            "Artífice",
             "Bardo",
             "Feiticeiro",
             "Mago"
@@ -19241,6 +19272,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Mago"
         ],
@@ -19436,6 +19468,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Bruxo",
             "Mago"
@@ -19605,6 +19638,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Clérigo",
             "Druida",
@@ -19859,6 +19893,7 @@
     {
         "casting_time": "1 hora",
         "classes": [
+            "Artífice",
             "Bardo",
             "Clérigo",
             "Mago"
@@ -19942,6 +19977,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Mago"
         ],
@@ -19996,6 +20032,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Clérigo",
             "Druida",
@@ -20076,6 +20113,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Clérigo",
             "Druida"
         ],
@@ -20260,6 +20298,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Mago"
         ],
@@ -20340,6 +20379,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Druida"
         ],
@@ -20707,6 +20747,7 @@
     {
         "casting_time": "1 minuto ou Ritual",
         "classes": [
+            "Artífice",
             "Bardo",
             "Mago"
         ],
@@ -20870,6 +20911,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Feiticeiro",
             "Bruxo",
@@ -20930,6 +20972,7 @@
     {
         "casting_time": "Ação bônus",
         "classes": [
+            "Artífice",
             "Druida",
             "Patrulheiro",
             "Feiticeiro",
@@ -21013,6 +21056,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Mago"
         ],
         "components": [
@@ -21066,6 +21110,7 @@
     {
         "casting_time": "Ação bônus",
         "classes": [
+            "Artífice",
             "Bardo",
             "Clérigo",
             "Druida",
@@ -21094,6 +21139,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Mago"
         ],
@@ -21122,6 +21168,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Clérigo",
             "Feiticeiro",
@@ -21295,6 +21342,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Druida",
             "Patrulheiro",
@@ -21352,6 +21400,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Feiticeiro",
             "Bruxo",
@@ -21461,6 +21510,7 @@
     {
         "casting_time": "1 minuto ou Ritual",
         "classes": [
+            "Artífice",
             "Bardo",
             "Mago"
         ],
@@ -21488,6 +21538,7 @@
     {
         "casting_time": "Ação bônus",
         "classes": [
+            "Artífice",
             "Paladino",
             "Patrulheiro",
             "Feiticeiro",
@@ -21759,6 +21810,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Druida",
             "Feiticeiro",
@@ -22077,6 +22129,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Mago"
         ],
         "components": [
@@ -22130,6 +22183,7 @@
     {
         "casting_time": "10 minutos",
         "classes": [
+            "Artífice",
             "Mago"
         ],
         "components": [
@@ -22296,6 +22350,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Mago"
         ],
         "components": [
@@ -22593,6 +22648,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Druida",
             "Feiticeiro",
             "Bruxo",
@@ -22776,6 +22832,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Feiticeiro",
             "Bruxo",
@@ -22935,6 +22992,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Clérigo",
             "Druida",
             "Patrulheiro",
@@ -22995,6 +23053,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Clérigo",
             "Druida",
             "Paladino",
@@ -23022,6 +23081,7 @@
     {
         "casting_time": "Ação ou Ritual",
         "classes": [
+            "Artífice",
             "Clérigo",
             "Druida",
             "Paladino"
@@ -23129,6 +23189,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Mago"
         ],
@@ -23262,6 +23323,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Clérigo",
             "Druida"
         ],
@@ -23344,6 +23406,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Clérigo",
             "Druida",
             "Paladino",
@@ -23373,6 +23436,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Mago"
         ],
         "components": [
@@ -23424,6 +23488,7 @@
     {
         "casting_time": "Ação bônus",
         "classes": [
+            "Artífice",
             "Clérigo"
         ],
         "components": [
@@ -23531,6 +23596,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Feiticeiro",
             "Mago"
@@ -23801,6 +23867,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Mago"
         ],
@@ -24021,6 +24088,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Clérigo",
             "Druida"
         ],
@@ -24128,6 +24196,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Bruxo",
             "Mago"
@@ -24345,6 +24414,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Clérigo",
             "Druida",
             "Mago"
@@ -24373,6 +24443,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Druida",
             "Patrulheiro",
             "Feiticeiro",
@@ -24544,6 +24615,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Mago"
         ],
         "components": [
@@ -25072,6 +25144,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Druida"
         ],
         "components": [
@@ -25099,6 +25172,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Druida",
             "Feiticeiro",
@@ -25395,6 +25469,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Bardo",
             "Feiticeiro",
             "Bruxo",
@@ -25642,6 +25717,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Druida",
             "Feiticeiro",
             "Mago"
@@ -25726,6 +25802,7 @@
     {
         "casting_time": "Ação ou Ritual",
         "classes": [
+            "Artífice",
             "Druida",
             "Patrulheiro",
             "Feiticeiro",
@@ -25755,6 +25832,7 @@
     {
         "casting_time": "Ação ou Ritual",
         "classes": [
+            "Artífice",
             "Clérigo",
             "Druida",
             "Patrulheiro",
@@ -25784,6 +25862,7 @@
     {
         "casting_time": "Ação",
         "classes": [
+            "Artífice",
             "Feiticeiro",
             "Mago"
         ],


### PR DESCRIPTION
This PR updates the 2024 spells to use the Artificer list from Eberron: Forge of the Artificer.